### PR TITLE
fix: 基质挑战采用右下方1/4区域进行匹配，避免误触

### DIFF
--- a/src/interaction/ScreenPosition.py
+++ b/src/interaction/ScreenPosition.py
@@ -32,6 +32,10 @@ class ScreenPosition:
         return Box(x=self.parent.width // 2, y=self.parent.height // 2, to_x=self.parent.width, to_y=self.parent.height)
 
     @property
+    def bottom_right_quarter(self) -> Box:
+        return Box(x=self.parent.width * 3 // 4, y=self.parent.height * 3 // 4, to_x=self.parent.width, to_y=self.parent.height)
+
+    @property
     def left(self) -> Box:
         return Box(x=0, y=0, to_x=self.parent.width // 2, to_y=self.parent.height)
 

--- a/src/tasks/daily/daily_battle_mixin.py
+++ b/src/tasks/daily/daily_battle_mixin.py
@@ -416,8 +416,8 @@ class DailyBattleMixin(MapMixin, ZipLineMixin, BattleMixin, Common):
                 self.wait_click_ocr(match=re.compile("重新挑战"), box=self.box.bottom_left, log=True, time_out=5,
                                     after_sleep=2, recheck_time=1)
             else:
-                # 根据 enter_str 决定点击位置，如果是「挑战」，则点击右下四分之一区域，避免误触
-                enter_box = self.box.bottom_right_quarter if enter_str == "挑战" else self.box.bottom_right
+                # 根据 enter_str 决定点击位置，如果是「挑战」，并且刷取的是「能量淤积点」，则点击右下四分之一区域，避免误触
+                enter_box = self.box.bottom_right_quarter if enter_str == "挑战" and stage_name == "能量淤积点" else self.box.bottom_right
                 self.wait_click_ocr(match=re.compile(enter_str), time_out=10, after_sleep=2, box=enter_box,
                                     log=True, recheck_time=1)
                 enter_bool = True

--- a/src/tasks/daily/daily_battle_mixin.py
+++ b/src/tasks/daily/daily_battle_mixin.py
@@ -416,7 +416,7 @@ class DailyBattleMixin(MapMixin, ZipLineMixin, BattleMixin, Common):
                 self.wait_click_ocr(match=re.compile("重新挑战"), box=self.box.bottom_left, log=True, time_out=5,
                                     after_sleep=2, recheck_time=1)
             else:
-                # 根据 enter_str 决定点击位置，如果是「挑战」，并且刷取的是「能量淤积点」，则点击右下四分之一区域，避免误触
+                # 根据 enter_str 决定点击位置, 如果是「挑战」, 并且刷取的是「能量淤积点」, 则点击右下四分之一区域, 避免误触
                 enter_box = self.box.bottom_right_quarter if enter_str == "挑战" and stage_name == "能量淤积点" else self.box.bottom_right
                 self.wait_click_ocr(match=re.compile(enter_str), time_out=10, after_sleep=2, box=enter_box,
                                     log=True, recheck_time=1)

--- a/src/tasks/daily/daily_battle_mixin.py
+++ b/src/tasks/daily/daily_battle_mixin.py
@@ -411,13 +411,13 @@ class DailyBattleMixin(MapMixin, ZipLineMixin, BattleMixin, Common):
 
     def battle_recycle(self, left_ticket, stage_name, category_name, enter_str, no_battle=False, challenge_check=False):
         enter_bool = False
-        # 根据 enter_str 决定点击位置，如果是「挑战」，则点击右下四分之一区域，避免误触
-        enter_box = self.box.bottom_right_quarter if enter_str == "挑战" else self.box.bottom_right
         while left_ticket > 0:
             if enter_bool:
                 self.wait_click_ocr(match=re.compile("重新挑战"), box=self.box.bottom_left, log=True, time_out=5,
                                     after_sleep=2, recheck_time=1)
             else:
+                # 根据 enter_str 决定点击位置，如果是「挑战」，则点击右下四分之一区域，避免误触
+                enter_box = self.box.bottom_right_quarter if enter_str == "挑战" else self.box.bottom_right
                 self.wait_click_ocr(match=re.compile(enter_str), time_out=10, after_sleep=2, box=enter_box,
                                     log=True, recheck_time=1)
                 enter_bool = True

--- a/src/tasks/daily/daily_battle_mixin.py
+++ b/src/tasks/daily/daily_battle_mixin.py
@@ -411,12 +411,14 @@ class DailyBattleMixin(MapMixin, ZipLineMixin, BattleMixin, Common):
 
     def battle_recycle(self, left_ticket, stage_name, category_name, enter_str, no_battle=False, challenge_check=False):
         enter_bool = False
+        # 根据 enter_str 决定点击位置，如果是「挑战」，则点击右下四分之一区域，避免误触
+        enter_box = self.box.bottom_right_quarter if enter_str == "挑战" else self.box.bottom_right
         while left_ticket > 0:
             if enter_bool:
                 self.wait_click_ocr(match=re.compile("重新挑战"), box=self.box.bottom_left, log=True, time_out=5,
                                     after_sleep=2, recheck_time=1)
             else:
-                self.wait_click_ocr(match=re.compile(enter_str), time_out=10, after_sleep=2, box=self.box.bottom_right,
+                self.wait_click_ocr(match=re.compile(enter_str), time_out=10, after_sleep=2, box=enter_box,
                                     log=True, recheck_time=1)
                 enter_bool = True
             if not self.to_battle(no_battle=no_battle, challenge_check=challenge_check):


### PR DESCRIPTION
<img width="1920" height="1080" alt="Windows Graphics Capture_1920x1080_1777025608703 9502_original" src="https://github.com/user-attachments/assets/44d7147f-170f-4a20-9042-58d3328ba1c4" />

## 核心问题
刷取基质，开启挑战时，需要匹配**挑战**两字
但是上图中，“今日**挑战**次数较多”中包含了**挑战**两字，导致误触

## 解决方案
使用了右下方1/4区域进行匹配

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved click targeting for a specific challenge in daily battles: the tap area is now more precise (smaller bottom-right quarter) for that stage, reducing unintended taps and improving interaction reliability during retries while keeping OCR matching and retry timing unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->