### PR TITLE
优化影拓丰碑进入流程

### DIFF
--- a/src/tasks/YingTuoTask.py
+++ b/src/tasks/YingTuoTask.py
@@ -47,9 +47,11 @@ class YingTuoTask(BattleMixin):
     def enter_yingtuo(self):
         self.log_info("开始影拓丰碑任务", notify=True)
         self.press_key("f8", after_sleep=2)
-        if not self.wait_click_feature(feature=fL.resident_icon, time_out=10, raise_if_not_found=False, after_sleep=2):
-            self.log_info("未能进入常驻战斗页，任务结束", notify=True)
-            return False
+        # 如果当前不在常驻战斗页，先进入常驻战斗页
+        if not self.find_feature(feature=fL.yingtuo_entrance):
+            if not self.wait_click_feature(feature=fL.resident_icon, time_out=10, raise_if_not_found=False, after_sleep=2):
+                self.log_info("未能进入常驻战斗页，任务结束", notify=True)
+                return False
         if not self.wait_click_feature(feature=fL.yingtuo_entrance, time_out=10, raise_if_not_found=False):
             self.log_info("未能找到影拓入口，任务结束", notify=True)
             return False


### PR DESCRIPTION
## 问题描述
影拓丰碑停在【常驻战斗页】
报错信息：未能进入常驻战斗页，任务结束
<img width="1920" height="1080" alt="Windows Graphics Capture_1920x1080_1783097071790 2478_original" src="https://github.com/user-attachments/assets/a37cb3a8-2e3e-4b79-b7df-dc479022d10a" />

## 原因分析
之前的流程为：点击F8->模板匹配并点击【常驻】
而部分账户点击F8后会直接跳转到【常驻战斗页】
此时【常驻战斗页】模板匹配不上
因为此时常驻战斗页为
<img width="50" height="39" alt="e7c86695-74f0-4fcf-9d4e-178d63c8a4ad" src="https://github.com/user-attachments/assets/2adb36ec-5630-4b02-81cd-03e09c271030" />
与模板中的
<img width="58" height="44" alt="09911fca-ea8c-4293-ba64-645e9bf60d94" src="https://github.com/user-attachments/assets/26cc4b57-e8d9-408b-81ed-7abdbac6e836" />
不一致（位置及背景发生变化）

## 解决方案
提前判断是否已经可以找到【影拓丰碑】，找不到才做【常驻战斗页】的模板匹配