### PR TITLE
优化已追踪时的传送流程

### DIFF
--- a/docs/dev/API.md
+++ b/docs/dev/API.md
@@ -422,7 +422,7 @@ from src.tasks.mixin.map_mixin import MapMixin
 
 def task_to_transfer_point(self, need_location_list=None)
 def clear_icon_in_map(self, need_reserve_icon_name=None, ocr=False)
-def to_near_transfer_point(self, after_track, need_location_list=None)
+def to_near_transfer_point(self, need_track, need_location_list=None, need_reserve_icon_name=None)
 ```
 
 `task_to_transfer_point` 从任务界面定位地图，地图稳定后再调用 `to_near_transfer_point`。`to_near_transfer_point` 传送至附近传送点。

--- a/src/tasks/daily/daily_battle_mixin.py
+++ b/src/tasks/daily/daily_battle_mixin.py
@@ -230,9 +230,7 @@ class DailyBattleFeature:
 
     def _click_track_and_transfer(self):
         """点击『追踪』按钮，进入地图并传送至最近传送点。"""
-        if result := self.wait_feature(feature=fL.start_follow, box=self.box.bottom_right, time_out=5, raise_if_not_found=False):
-            self.click(result, after_sleep=1)
-        self.to_near_transfer_point(after_track=True, need_reserve_icon_name=fL.clear_page_gather)
+        self.to_near_transfer_point(need_track=True, need_reserve_icon_name=fL.clear_page_gather)
         self.ensure_main()
 
     def _navigate_via_zip_line(self):

--- a/src/tasks/daily/daily_demo_mixin.py
+++ b/src/tasks/daily/daily_demo_mixin.py
@@ -116,11 +116,7 @@ class DailyDemoFeature:
         
     def _demo_click_track_and_transfer(self):
         """点击『追踪』按钮，进入地图并传送至最近传送点。"""
-        if result := self.wait_feature(feature=fL.start_follow, box=self.box.bottom_right, time_out=5, raise_if_not_found=False):
-            self.click(result)
-        else:
-            self.log_info("未找到『追踪』按钮，继续尝试自动寻路")
-        if not self.to_near_transfer_point(after_track=True, need_reserve_icon_name=fL.clear_page_demo_battle):
+        if not self.to_near_transfer_point(need_track=True, need_reserve_icon_name=fL.clear_page_demo_battle):
             self.mark_task_failure("未能找到传送点，无法继续")
             return False
         self.ensure_main()

--- a/src/tasks/mixin/map_mixin.py
+++ b/src/tasks/mixin/map_mixin.py
@@ -61,7 +61,7 @@ class MapMixin(BaseEfTask):
         self.wait_ui_stable(refresh_interval=1)
 
         # 执行附近传送点传送
-        return self.to_near_transfer_point(after_track=False, need_location_list=need_location_list)
+        return self.to_near_transfer_point(need_track=False, need_location_list=need_location_list)
 
     def clear_icon_in_map(self, need_reserve_icon_name=None, ocr=False):
         """
@@ -121,19 +121,25 @@ class MapMixin(BaseEfTask):
 
         return True
 
-    def to_near_transfer_point(self, after_track, need_location_list=None, need_reserve_icon_name=None):
+    def to_near_transfer_point(self, need_track, need_location_list=None, need_reserve_icon_name=None):
         """
         在地图上寻找最近的传送点并执行传送。
 
         流程：
-        1. 打开“标记显示管理”。
-        2. 清空当前地图选中标记。
-        3. 重新点击屏幕中心（淤积点/演武平台需要点击，物资调度终端不需要）。
-        4. 在地图上搜索传送点图标。若找到则点击”前往传送“按钮。
-        5. 在地图上搜索传送点图标。若找到则点击”传送“按钮。
+        1. 需要追踪时：查找『追踪』按钮。（淤积点/演武平台需要追踪，物资调度终端不需要）
+           - 未找到『追踪』按钮
+             - 应已追踪，由后续『前往传送』逻辑查看『传送』按钮是否存在。
+           - 找到『追踪』按钮
+             - 点击『追踪』按钮进入地图；
+             - （可选）清空标记筛选；
+             - 点击屏幕中心。
+        2. 在地图上搜索传送点图标。若找到则点击『前往传送』按钮。
+        3. 在地图上搜索传送点图标。若找到则点击『传送』按钮。
 
         Args:
-            after_track: 调用函数前是否需要点击”追踪“按钮。
+            need_track: 调用函数前是否需要点击『追踪』按钮。需要时在函数内查找
+                该按钮：找到则点击，并执行清空标记筛选、点击屏幕中心；
+                未找到则跳过这些步骤（无需追踪时调用方应直接传 False）。
             need_location_list: 需要记录的候选地名列表（本地化名称）；
                 命中则把地图右上角显示的当前地区名记录到 self.location，供调用方回填缓存
 
@@ -153,50 +159,57 @@ class MapMixin(BaseEfTask):
             ):
                 self.location = location[0].name
 
-        # 调用函数前如果点击”追踪“按钮，需要再次点击屏幕中心图标。
-        if after_track:
-            if need_reserve_icon_name:
-                self.clear_icon_in_map(need_reserve_icon_name=need_reserve_icon_name)
-            self.click(0.5, 0.5, after_sleep=1)
-
-        # 查找“前往传送”按钮
-        # 先普通匹配；未找到时再尝试一次轮廓（Canny）匹配，对按钮反色/主题变化不敏感
-        result = self.wait_feature(
-            feature=fL.transfer_go,
-            time_out=10,
-            raise_if_not_found=False,
-            horizontal_variance=0.2,
-        )
-        if not result:
-            result = self.wait_feature(
-                feature=fL.transfer_go,
-                time_out=3,
+        if need_track:
+            # 需要追踪时：点击『追踪』按钮
+            tracked = self.wait_feature(
+                feature=fL.start_follow,
+                box=self.box.bottom_right,
+                time_out=5,
                 raise_if_not_found=False,
-                horizontal_variance=0.2,
-                canny_lower=50,
-                canny_higher=150,
-                threshold=0.8,
             )
+            if not tracked:
+                self.log_info("未找到『追踪』按钮，应该已追踪，尝试直接传送")
+            else:
+                # 点击追踪
+                self.click(tracked, after_sleep=1)
+                # 若需要清空标记筛选时，清空标记筛选并点击屏幕中心
+                if need_reserve_icon_name:
+                    self.clear_icon_in_map(need_reserve_icon_name=need_reserve_icon_name)
+                # 点击追踪后，需要重新点击屏幕中心激活按钮准备点击传送按钮
+                self.click(0.5, 0.5, after_sleep=1)
 
-        # 如果未找到“前往传送”按钮
-        if not result:
+        # 点击『前往传送』按钮（『前往传送』按钮与『传送』按钮一致但需要横向容差）
+        if not self._wait_click_transfer_go(horizontal_variance=0.2):
             return False
+        # 点击『传送』按钮
+        return self._wait_click_transfer_go()
 
-        # 点击”前往传送“按钮
-        self.click(result, after_sleep=1)
+    def _wait_click_transfer_go(self, horizontal_variance=0):
+        """
+        查找并点击『传送』按钮。
 
-        # 查找“传送”按钮
-        # 先普通匹配；未找到时再尝试一次轮廓（Canny）匹配，对按钮反色/主题变化不敏感
+        先普通匹配；未找到时再尝试一次轮廓（Canny）匹配，对按钮反色/主题变化不敏感。
+
+        Args:
+            horizontal_variance: 模板匹配的横向容差，默认 0（不启用）。
+
+        Returns:
+            bool: 找到并点击返回 True，否则 False。
+        """
+        # 查找『传送』按钮
         result = self.wait_feature(
             feature=fL.transfer_go,
             time_out=10,
             raise_if_not_found=False,
+            horizontal_variance=horizontal_variance,
         )
+        # 未找到时再尝试一次轮廓（Canny）匹配，对按钮反色/主题变化不敏感
         if not result:
             result = self.wait_feature(
                 feature=fL.transfer_go,
                 time_out=3,
                 raise_if_not_found=False,
+                horizontal_variance=horizontal_variance,
                 canny_lower=50,
                 canny_higher=150,
                 threshold=0.8,
@@ -206,7 +219,7 @@ class MapMixin(BaseEfTask):
         if not result:
             return False
 
-        # 点击”传送“按钮
+        # 点击『传送』按钮
         self.click(result, after_sleep=1)
 
         return True

--- a/src/tasks/mixin/map_mixin.py
+++ b/src/tasks/mixin/map_mixin.py
@@ -173,8 +173,10 @@ class MapMixin(BaseEfTask):
                 # 点击追踪
                 self.click(tracked, after_sleep=1)
                 # 若需要清空标记筛选时，清空标记筛选并点击屏幕中心
-                if need_reserve_icon_name:
-                    self.clear_icon_in_map(need_reserve_icon_name=need_reserve_icon_name)
+                if need_reserve_icon_name and not self.clear_icon_in_map(
+                    need_reserve_icon_name=need_reserve_icon_name
+                ):
+                    return False
                 # 点击追踪后，需要重新点击屏幕中心激活按钮准备点击传送按钮
                 self.click(0.5, 0.5, after_sleep=1)
 

--- a/tests/TestStateDrivenWaits.py
+++ b/tests/TestStateDrivenWaits.py
@@ -191,7 +191,7 @@ class _TaskMapHarness:
     def wait_ui_stable(self, **kwargs):
         self.stable_waits += 1
 
-    def to_near_transfer_point(self, after_track, need_location_list=None):
+    def to_near_transfer_point(self, need_track, need_location_list=None, need_reserve_icon_name=None):
         return True
 
 


### PR DESCRIPTION
## 改动

- 优化已追踪时的传送流程，不再需要点击地图中心，不再需要清空标记（详见下列流程图）
- 抽象出函数_wait_click_transfer_go
  - 传送图标具有悬浮效果，所以点击传送均应使用该函数
  - 该函数使得『前往传送』和『传送』可以复用代码
- 合并点击追踪逻辑进入to_near_transfer_point
  - 流程内聚，消除重复
  - 是否点击追踪及其之后的行为与to_near_transfer_point高度耦合，应属于to_near_transfer_point职责范围内
  - 不确定是否可以改用wait_click_feature
- 该改动只涉及追踪相关的逻辑，与送货无关

```
1. 主入口：to_near_transfer_point(need_track=True)
   └─ 功能变化：PR 后合并查找『追踪』按钮的逻辑

2. 查找『追踪』按钮
   │
   ├─ 找到 → 点击追踪 → 清空标记筛选(可选) → 点击屏幕中心 （找到『追踪』按钮后的逻辑不变）
   │
   └─ 未找到 → 消除多余点击（PR 前未找到仍执行清筛选+点屏幕中心）
   │
   ▼
3. 『前往传送』→『传送』（普通匹配 + Canny 兜底）
   └─ 行为与 PR 前一致
```

## 测试
* 有无追踪的情况下，刷体力和演武均可通过
* 送货可以正常传送至四号谷地
<img width="1160" height="788" alt="29e57d88-a98a-447d-b1ed-5d198e47d8bc" src="https://github.com/user-attachments/assets/3b8c7cb7-8ec6-461f-a689-feb6b8dbc15a" />



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能优化**
  * 优化追踪与传送流程，减少手动识别追踪按钮的步骤。
  * 未检测到追踪按钮时，可直接尝试传送。
  * 改进传送目标识别与点击操作，提升流程适应性。
  * 支持配置是否追踪、保留的图标名称及位置列表。

* **文档**
  * 更新传送接口参数说明，反映最新的追踪与图标配置选项。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->