### PR TITLE
chore: 适配本地 ok-script 的测试与工具

### DIFF
--- a/tests/TestEfInteraction.py
+++ b/tests/TestEfInteraction.py
@@ -11,6 +11,7 @@ class TestEfInteraction(unittest.TestCase):
     @patch("src.interaction.EfInteraction.active_and_send_mouse_delta")
     @patch("src.interaction.EfInteraction.win32gui")
     def test_back_posts_escape_without_forcing_foreground(self, win32gui, activate, sleep):
+        interaction = EfInteraction.__new__(EfInteraction)
         interaction._last_key_log_times = {}  # 本地 ok-script BaseInteraction.send_key 新增的日志间隔表
         interaction.keyboard = MagicMock()
         interaction._game_hwnd = MagicMock(return_value=200)

--- a/tests/TestEfInteraction.py
+++ b/tests/TestEfInteraction.py
@@ -11,7 +11,7 @@ class TestEfInteraction(unittest.TestCase):
     @patch("src.interaction.EfInteraction.active_and_send_mouse_delta")
     @patch("src.interaction.EfInteraction.win32gui")
     def test_back_posts_escape_without_forcing_foreground(self, win32gui, activate, sleep):
-        interaction = EfInteraction.__new__(EfInteraction)
+        interaction._last_key_log_times = {}  # 本地 ok-script BaseInteraction.send_key 新增的日志间隔表
         interaction.keyboard = MagicMock()
         interaction._game_hwnd = MagicMock(return_value=200)
         interaction._esc_hwnd = 0


### PR DESCRIPTION
拆分自原"适配测试与工具"（tools/fix_schedule_task_refs.py 已拆到 wait/schedule-index-sync-patches，等 ok-script 合入 PR #87 后合并）。

## 改动
- tests/TestEfInteraction.py：本地 ok-script BaseInteraction.send_key 新增 _last_key_log_times 依赖，测试初始化补齐

## 依赖链
根：ok-script 更新到本地 master（send_key 改动已合入上游）
本 PR 依赖已合入的 send_key 改动，可合。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **测试**
  * 更新按键交互测试的初始化逻辑，使其与按键操作的日志记录机制保持一致。
  * 提升相关测试的稳定性与兼容性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->