### PR TITLE
fix(gui): ConditionalRotationPanel 遵循 LabelAnd* 控件 self.layout 属性约定，修复子配置缩进渲染崩溃

### DIFF
--- a/src/gui/ConditionalRotationPanel.py
+++ b/src/gui/ConditionalRotationPanel.py
@@ -945,9 +945,12 @@ class ConditionalRotationPanel(QWidget):
         self._load()
 
     def _setup_ui(self):
-        layout = QVBoxLayout(self)
-        layout.setContentsMargins(0, 0, 0, 0)
-        layout.setSpacing(0)
+        # 与 LabelAnd* 控件保持一致的约定：把主布局存为 self.layout 属性（遮蔽 Qt 的
+        # layout() 方法），使 ConfigCard 的子配置缩进处理（widget.layout 直接取布局
+        # 实例）对本面板同样成立，无需框架侧额外兼容。
+        self.layout = QVBoxLayout(self)
+        self.layout.setContentsMargins(0, 0, 0, 0)
+        self.layout.setSpacing(0)
 
         # Row 1: 启用实时条件
         self._row1 = LabelAndWidget(KEY_COND_ENABLED, BATTLE_CONFIG_DESCRIPTION[KEY_COND_ENABLED])
@@ -956,7 +959,7 @@ class ConditionalRotationPanel(QWidget):
         self.enable_switch.setOffText(_tr("否"))
         self.enable_switch.checkedChanged.connect(lambda c: self._set_config(KEY_COND_ENABLED, c))
         self._row1.add_widget(self.enable_switch, stretch=0)
-        layout.addWidget(self._row1)
+        self.layout.addWidget(self._row1)
 
         # Row 2: 立即释放终结技
         self._row2 = LabelAndWidget(KEY_INSTANT_ULT, BATTLE_CONFIG_DESCRIPTION[KEY_INSTANT_ULT])
@@ -965,7 +968,7 @@ class ConditionalRotationPanel(QWidget):
         self.ult_switch.setOffText(_tr("否"))
         self.ult_switch.checkedChanged.connect(lambda c: self._set_config(KEY_INSTANT_ULT, c))
         self._row2.add_widget(self.ult_switch, stretch=0)
-        layout.addWidget(self._row2)
+        self.layout.addWidget(self._row2)
 
         # Row 3: 立即释放连携技
         self._row3 = LabelAndWidget(KEY_INSTANT_LINK, BATTLE_CONFIG_DESCRIPTION[KEY_INSTANT_LINK])
@@ -974,7 +977,7 @@ class ConditionalRotationPanel(QWidget):
         self.link_switch.setOffText(_tr("否"))
         self.link_switch.checkedChanged.connect(lambda c: self._set_config(KEY_INSTANT_LINK, c))
         self._row3.add_widget(self.link_switch, stretch=0)
-        layout.addWidget(self._row3)
+        self.layout.addWidget(self._row3)
 
         # Row 4: 动作列表 + 编辑按钮
         self._row4 = LabelAndWidget(_tr("动作列表"), _tr("当条件符合时使用技能组"))
@@ -982,7 +985,7 @@ class ConditionalRotationPanel(QWidget):
         self.edit_btn = PushButton(FluentIcon.EDIT, _tr("编辑"))
         self.edit_btn.clicked.connect(self._on_edit)
         self._row4.add_widget(self.edit_btn, stretch=0)
-        layout.addWidget(self._row4)
+        self.layout.addWidget(self._row4)
 
     def _load(self):
         self._loading = True


### PR DESCRIPTION
## 背景

ok-script 的 `ConfigCard.__addConfig` 在渲染子配置（sub_config）项时，用 `widget.layout` 直接取控件布局对象做缩进处理（`contentsMargins()` / `setContentsMargins()` + `SUBCONFIG_INDENT`）。

框架约定：所有 config 控件（`LabelAnd*` 系列、`ModifyListItem`）都通过 `self.layout = QHBoxLayout(self)` 把布局存为**实例属性**（遮蔽 Qt 的 `layout()` 方法），因此 `widget.layout` 拿到的是布局实例。

## 问题

`src/gui/ConditionalRotationPanel.py` 的 `ConditionalRotationPanel` 直接继承 `QWidget`，主布局 `QVBoxLayout` 只存为局部变量 `layout`，未挂到 `self.layout`。于是 `widget.layout` 是 **Qt 原生方法**（`builtin_function_or_method`），`ConfigCard` 调用 `layout.contentsMargins()` 时崩溃：

```
AttributeError: 'builtin_function_or_method' object has no attribute 'contentsMargins'
```

该面板由 `src/patches/conditional_rotation_patch.py` 作为「启用实时条件」配置项渲染，而该配置项（`KEY_COND_ENABLED`）是战斗配置（`battle_mixin`）的子配置项，渲染时必然走进上述缩进分支 → 应用启动即崩（`TriggerTaskTab` → `AutoCombatTask` 配置渲染阶段）。

## 修复

让 `ConditionalRotationPanel` 遵循框架所有 config 控件的统一约定：把主布局存为 `self.layout` 属性（遮蔽 Qt 方法），使 `widget.layout` 直接返回布局实例。

- **项目侧修复，不改动框架代码**
- 修复后 `ConditionalRotationPanel.layout` 实测为 `QVBoxLayout`（`callable=False`），与 `LabelAnd*` 语义一致
- 验证：应用完整启动（`Loaded 9 tasks` / `main window __init__ done` / `Window has fully displayed`），无崩溃

## 影响

仅 `src/gui/ConditionalRotationPanel.py` 一个文件（17 行改动：10 增 7 删）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化条件旋转面板的界面布局管理。
  * 保持现有布局的边距和间距不变，用户界面显示效果无变化。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->