### PR TITLE
feat(config): 多账户模式改布尔开关显隐，送货测试对象下拉加 sub_configs

### DIFF
--- a/src/tasks/account/account_mixin.py
+++ b/src/tasks/account/account_mixin.py
@@ -28,7 +28,7 @@ class AccountMixin(LoginMixin):
         self.default_config_group.update({
             "多账户模式": ["多账户模式"],
         })
-        # 「多账户模式」开关：开启后展开显示「多账户独立配置」和「账号列表」两个子选项
+        # 「多账户模式」开关: 开启后展开显示「多账户独立配置」和「账号列表」两个子选项
         if not hasattr(self, "config_type") or self.config_type is None:
             self.config_type = {}
         self.config_type["多账户模式"] = {

--- a/src/tasks/account/account_mixin.py
+++ b/src/tasks/account/account_mixin.py
@@ -26,8 +26,16 @@ class AccountMixin(LoginMixin):
             ),
         })
         self.default_config_group.update({
-            "多账户模式": ["多账户模式", "多账户独立配置", "账号列表"],
+            "多账户模式": ["多账户模式"],
         })
+        # 「多账户模式」开关：开启后展开显示「多账户独立配置」和「账号列表」两个子选项
+        if not hasattr(self, "config_type") or self.config_type is None:
+            self.config_type = {}
+        self.config_type["多账户模式"] = {
+            "sub_configs": {
+                True: ["多账户独立配置", "账号列表"],
+            },
+        }
 
     def get_account_list(self):
         account_str = self.config.get("账号列表", "")

--- a/src/tasks/onetime/DeliveryTask.py
+++ b/src/tasks/onetime/DeliveryTask.py
@@ -136,6 +136,10 @@ class DeliveryTask(AccountMixin, ZipLineMixin, MapMixin):
         self.config_type[self.CFG_TEST_TARGET] = {
             "type": "drop_down",
             "options": [self.TEST_NONE] + self.to_delivery_point_config_keys + self.ends + [self.TEST_FULL_CYCLE],
+            "sub_configs": {
+                self.TEST_NONE: [self.CFG_ONLY_ACCEPT, self.CFG_ONLY_DELIVER],
+                self.TEST_FULL_CYCLE: [self.CFG_FULL_CYCLE_LOCATION],
+            },
         }
         self.config_type[self.CFG_DELIVERY_AREA] = {
             "type": "drop_down",


### PR DESCRIPTION
## 变更内容

1. **多账户模式改布尔开关显隐**（\ccount_mixin.py\）
   - \default_config_group['多账户模式']\ 只保留「多账户模式」开关
   - 「多账户独立配置」「账号列表」改由开关的 \sub_configs(True键)\ 展开显隐
   - 修复同一 sub 键被分组与开关双重声明导致的「重置配置」按钮位置错乱布局 bug

2. **送货测试对象下拉加 sub_configs**（\DeliveryTask.py\）
   - \CFG_TEST_TARGET\ 下拉为「无」「全周期」选项声明子配置项

## 测试
- 完整测试套件与本分支基线一致，无新增失败
- 修复子项重复插入导致的布局错位

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 优化多账户模式配置展示：启用开关后，可展开查看多账户独立配置及账号列表。
  * 新增测试目标细分选项：根据测试模式显示仅接取、仅送货或完整循环测试区域。

* **改进**
  * 配置界面根据所选模式动态展示相关选项，提升设置体验。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->