### PR TITLE
test: 清理断言与图标路径测试

### DIFF
--- a/tests/TestCheckLang.py
+++ b/tests/TestCheckLang.py
@@ -144,7 +144,7 @@ class LangTestCase(unittest.TestCase):
                             f"{file_path} -> {lang_group}.json"
                         )
 
-                        print("     ❌", msg)
+                        print("     [X]", msg)
 
                         missing.append(msg)
 
@@ -165,7 +165,7 @@ class LangTestCase(unittest.TestCase):
                             missing_langs.append(locale_code)
 
                             print(
-                                f"     ⚠️ MISSING locale {locale_code}"
+                                f"     [!] MISSING locale {locale_code}"
                             )
 
                             continue
@@ -173,7 +173,7 @@ class LangTestCase(unittest.TestCase):
                         if key in lang_data:
 
                             print(
-                                f"     ✅ FOUND in {locale_code}"
+                                f"     [OK] FOUND in {locale_code}"
                             )
 
                             found_langs.append(locale_code)
@@ -181,7 +181,7 @@ class LangTestCase(unittest.TestCase):
                         else:
 
                             print(
-                                f"     ⚠️ MISSING key in {locale_code}"
+                                f"     [!] MISSING key in {locale_code}"
                             )
 
                             missing_langs.append(locale_code)
@@ -199,7 +199,7 @@ class LangTestCase(unittest.TestCase):
                             f"(missing in ALL languages)"
                         )
 
-                        print("     ❌", msg)
+                        print("     [X]", msg)
 
                         missing.append(msg)
 

--- a/tests/TestCheckLang.py
+++ b/tests/TestCheckLang.py
@@ -87,6 +87,12 @@ class LangTestCase(unittest.TestCase):
     def collect_missing(self):
 
         # 完全缺失（FAIL）
+        """
+        Scan source files for language references and collect missing-file and fully missing-key errors.
+        
+        Returns:
+            list[str]: Error messages for language files or keys missing from all supported locales.
+        """
         missing = []
 
         # 部分缺失（WARNING）

--- a/tests/TestGifIcon.py
+++ b/tests/TestGifIcon.py
@@ -12,7 +12,7 @@ from pathlib import Path
 from PIL import Image
 from PySide6.QtCore import QEventLoop, QTimer
 from PySide6.QtWidgets import QApplication
-from qfluentwidgets import FluentIcon
+from qfluentwidgets import FluentIcon, Theme
 from qfluentwidgets.components.widgets.icon_widget import IconWidget
 
 import src.icons as icons_module
@@ -97,7 +97,8 @@ class GifIconTestCase(unittest.TestCase):
         # png/svg 走原有渲染路径，不应被 GIF 逻辑影响
         png = ThemeIcon("a", "b", suffix=".png", base_path=self.tmp)
         self.assertFalse(png._is_gif)
-        self.assertEqual(png.path(), str(self.tmp / "a.png"))
+        self.assertEqual(png.path(Theme.LIGHT), str(self.tmp / "a.png"))
+        self.assertEqual(png.path(Theme.DARK), str(self.tmp / "b.png"))
 
     def test_theme_icon_rejects_bad_suffix(self):
         with self.assertRaises(AssertionError):


### PR DESCRIPTION
## 变更内容

1. **\TestCheckLang.py\**：打印信息用 \[OK]/[X]/[!]\ 替代 emoji，修复 Windows gbk 控制台打印 emoji（✅❌⚠️）时的 \UnicodeEncodeError\ 导致测试失败的问题
2. **\TestGifIcon.py\**：png/svg 路径断言改为显式传 \Theme.LIGHT/DARK\，适配 \ThemeIcon.path()\ 签名

## 测试
- 完整测试套件 276 个全部通过（修复 master 上 \	est_lang_keys_valid\ 因 emoji 编码失败的问题）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 统一语言检查结果的状态标识，提升缺失文件、缺失语言及缺失键提示的一致性与可读性。
  * 补充浅色和深色主题图标路径的测试验证，确保两种主题下均能正确使用对应图标。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->