### PR TITLE
fix: 修复缺失 PATH 环境变量时进程启动失败问题

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,14 @@
-from src.config import config
-from src.patches.startup_patches import install_startup_patches
+from src.patches.pre_config_patch import install_pre_config_patch
 
-if __name__ == '__main__':
+install_pre_config_patch()
+
+from src.config import config  # noqa: E402
+from src.patches.startup_patches import install_startup_patches  # noqa: E402
+
+if __name__ == "__main__":
     config = config
     install_startup_patches()
     import ok
+
     ok = ok.OK(config)
     ok.start()

--- a/main_debug.py
+++ b/main_debug.py
@@ -1,10 +1,15 @@
-from src.config import config
-from src.patches.startup_patches import install_startup_patches
+from src.patches.pre_config_patch import install_pre_config_patch
 
-if __name__ == '__main__':
+install_pre_config_patch()
+
+from src.config import config  # noqa: E402
+from src.patches.startup_patches import install_startup_patches  # noqa: E402
+
+if __name__ == "__main__":
     config = config
-    config['debug'] = True
+    config["debug"] = True
     install_startup_patches()
     import ok
+
     ok = ok.OK(config)
     ok.start()

--- a/src/core/email_config.py
+++ b/src/core/email_config.py
@@ -7,12 +7,7 @@
 """
 from __future__ import annotations
 
-import os
 from ok import ConfigOption
-
-# WA: set empty PATH to resolve qfluentwidgets access os.environ['PATH'] issue
-if "PATH" not in os.environ:
-    os.environ["PATH"] = ""
 from qfluentwidgets import FluentIcon
 
 EMAIL_CONFIG_NAME = "Email Config"

--- a/src/core/email_config.py
+++ b/src/core/email_config.py
@@ -8,6 +8,10 @@
 from __future__ import annotations
 
 from ok import ConfigOption
+
+# WA: set empty PATH to resolve qfluentwidgets access os.environ['PATH'] issue
+if "PATH" not in os.environ:
+    os.environ["PATH"] = ""
 from qfluentwidgets import FluentIcon
 
 EMAIL_CONFIG_NAME = "Email Config"

--- a/src/core/email_config.py
+++ b/src/core/email_config.py
@@ -7,6 +7,7 @@
 """
 from __future__ import annotations
 
+import os
 from ok import ConfigOption
 
 # WA: set empty PATH to resolve qfluentwidgets access os.environ['PATH'] issue

--- a/src/patches/pre_config_patch.py
+++ b/src/patches/pre_config_patch.py
@@ -8,6 +8,6 @@ def install_pre_config_patch():
     Raises:
         None
     """
-    # WA: set empty PATH to resolve qfluentwidgets access os.environ['PATH'] issue
-    if "PATH" not in os.environ:
-        os.environ["PATH"] = ""
+    # WA: set default PATH to resolve qfluentwidgets access os.environ['PATH'] issue
+    # 使用 os.defpath 而非空串，避免非绝对路径命令（如 git/python）无法解析
+    os.environ.setdefault("PATH", os.defpath)

--- a/src/patches/pre_config_patch.py
+++ b/src/patches/pre_config_patch.py
@@ -1,0 +1,13 @@
+# -*- coding: utf-8 -*-
+import os
+
+
+def install_pre_config_patch():
+    """导入 src.config 前的预处理。
+
+    Raises:
+        None
+    """
+    # WA: set empty PATH to resolve qfluentwidgets access os.environ['PATH'] issue
+    if "PATH" not in os.environ:
+        os.environ["PATH"] = ""

--- a/tests/TestPreConfigPatch.py
+++ b/tests/TestPreConfigPatch.py
@@ -1,0 +1,56 @@
+# -*- coding: utf-8 -*-
+"""pre_config_patch 的单元测试：缺失 PATH 时用 os.defpath 补齐。
+
+背景
+----
+PySide6 导入时 _setupQtDirectories 会执行
+``os.environ['PATH'] = pyside_package_dir + os.pathsep + os.environ['PATH']``，
+当 PATH 环境变量不存在时抛 KeyError: 'PATH'，导致 ok-ef 无法启动
+（issue #191）。pre_config_patch 在导入 src.config 前先补齐 PATH。
+
+本测试验证：
+- 缺失 PATH 时 install_pre_config_patch 补上 os.defpath
+- 已有 PATH 时保持不变
+- 补齐后非绝对路径命令仍可被 os.get_exec_path 解析
+
+隔离策略
+--------
+仅操作 os.environ['PATH']，并在 setUp/tearDown 中保存恢复，不影响其它测试。
+不构造 ok 全局，不依赖 qfluentwidgets / PySide6 导入。
+"""
+import os
+import unittest
+
+from src.patches.pre_config_patch import install_pre_config_patch
+
+
+class TestPreConfigPatch(unittest.TestCase):
+
+    def setUp(self):
+        self._saved_path = os.environ.get("PATH")
+
+    def tearDown(self):
+        if self._saved_path is None:
+            os.environ.pop("PATH", None)
+        else:
+            os.environ["PATH"] = self._saved_path
+
+    def test_sets_defpath_when_path_missing(self):
+        os.environ.pop("PATH", None)
+        install_pre_config_patch()
+        self.assertIn("PATH", os.environ)
+        self.assertEqual(os.environ["PATH"], os.defpath)
+
+    def test_preserves_existing_path(self):
+        os.environ["PATH"] = "C:\\existing\\bin"
+        install_pre_config_patch()
+        self.assertEqual(os.environ["PATH"], "C:\\existing\\bin")
+
+    def test_bare_command_resolvable_after_patch(self):
+        os.environ.pop("PATH", None)
+        install_pre_config_patch()
+        self.assertTrue(os.get_exec_path())
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
fix https://github.com/AliceJump/ok-end-field/issues/191

## 解决方案

新增 src/patches/pre_config_patch.py 的 install_pre_config_patch()，
在 main.py / main_debug.py 导入 src.config 之前调用，
缺失 PATH 时设为默认值兜底。

## 修复结果
ok-ef可以正常启动

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - 优化程序启动前的环境初始化流程。
  - 加载配置前检查运行环境中的 `PATH` 设置，缺失时自动补全为系统默认路径，提升启动稳定性。
  - 调试模式与正常启动流程均同步支持该改进。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->