### PR TITLE
fix: 修复 SonarCloud 报警（6 类真实缺陷项）

### DIFF
--- a/.github/workflows/smoke-tags.yml
+++ b/.github/workflows/smoke-tags.yml
@@ -101,9 +101,11 @@ jobs:
         shell: pwsh
         continue-on-error: true
         timeout-minutes: 300
+        env:
+          WAIT_SECONDS: ${{ inputs.wait_seconds }}
         run: |
           ./scripts/smoke_test_tags.ps1 -Tags "${{ matrix.shard }}" `
-            -WaitSeconds ${{ inputs.wait_seconds }} `
+            -WaitSeconds $env:WAIT_SECONDS `
             -ResultFile "smoke_${{ strategy.job-index }}.csv" `
             -BadTagsFile "bad_${{ strategy.job-index }}.txt"
 

--- a/.github/workflows/smoke-tags.yml
+++ b/.github/workflows/smoke-tags.yml
@@ -103,8 +103,9 @@ jobs:
         timeout-minutes: 300
         env:
           WAIT_SECONDS: ${{ inputs.wait_seconds }}
+          SMOKE_TAGS: ${{ matrix.shard }}
         run: |
-          ./scripts/smoke_test_tags.ps1 -Tags "${{ matrix.shard }}" `
+          ./scripts/smoke_test_tags.ps1 -Tags $env:SMOKE_TAGS `
             -WaitSeconds $env:WAIT_SECONDS `
             -ResultFile "smoke_${{ strategy.job-index }}.csv" `
             -BadTagsFile "bad_${{ strategy.job-index }}.txt"

--- a/src/core/email_service.py
+++ b/src/core/email_service.py
@@ -286,6 +286,7 @@ def send_email(
 
     # 校验服务器证书，避免降级/中间人风险（SonarQube S4830）
     ssl_context = ssl.create_default_context()
+    ssl_context.minimum_version = ssl.TLSVersion.TLSv1_2
 
     if use_ssl:
         server = smtplib.SMTP_SSL(smtp_host, smtp_port, timeout=timeout, context=ssl_context)

--- a/src/image/gray_bar_detector.py
+++ b/src/image/gray_bar_detector.py
@@ -86,7 +86,7 @@ def detect_gray_bars(
         bar_width = end - start + 1
         if not min_width_px <= bar_width <= max_width_px:
             continue
-        ys, _ = np.where(mask[:, start:end + 1] > 0)
+        ys, _ = np.nonzero(mask[:, start:end + 1] > 0)
         if not len(ys):
             continue
         local_y1, local_y2 = int(ys.min()), int(ys.max())

--- a/src/image/rotated_template.py
+++ b/src/image/rotated_template.py
@@ -171,7 +171,7 @@ class ArrowAngleMatcher:
 
         # 基于 alpha 计算紧致 bbox
         alpha_mask = rotated_alpha_chan > 8
-        ys, xs = np.where(alpha_mask)
+        ys, xs = np.nonzero(alpha_mask)
 
         if ys.size == 0:
             bgr_cropped = rotated_bgr
@@ -342,7 +342,7 @@ def rotated_template_match(
 
         # 提取 bbox
         alpha_mask = rotated_alpha > 8
-        ys, xs = np.where(alpha_mask)
+        ys, xs = np.nonzero(alpha_mask)
 
         if ys.size == 0:
             continue

--- a/src/interaction/Mouse.py
+++ b/src/interaction/Mouse.py
@@ -371,5 +371,5 @@ def run_in_window(hwnd, func, *args, **kwargs):
         if need_restore and prev and win32gui.IsWindow(prev):
             try:
                 win32gui.SetForegroundWindow(prev)
-            except:
+            except Exception:
                 pass

--- a/src/tasks/onetime/DeliveryTask.py
+++ b/src/tasks/onetime/DeliveryTask.py
@@ -465,10 +465,7 @@ class DeliveryTask(AccountMixin, ZipLineMixin, MapMixin):
             self.log_info("未找到‘运送委托列表’，退出")
             return False
         self.wait_ui_stable(refresh_interval=1)
-        enable_delivery_area = True
-        ticket_types = []
-        if enable_delivery_area:
-            ticket_types.append("ticket_delivery_area")
+        ticket_types = ["ticket_delivery_area"]
 
         if not ticket_types:
             self.log_info("警告: 未启用任何券种，任务退出")

--- a/src/tasks/onetime/TakeDeliveryTask.py
+++ b/src/tasks/onetime/TakeDeliveryTask.py
@@ -56,12 +56,12 @@ class TakeDeliveryTask(BaseEfTask, TriggerTask):
                 if match:
                     try:
                         val = float(match.group(1))
-                        if val >= filter_min and val <= 100:
-                            rewards.append((t, val))  # 保存 OCR对象 和 提取出的数值
-                        elif val > 100:
-                            self.log_debug(f"金额异常过大({val}万)，可能是OCR误识别，已过滤")
-                    except Exception:
-                        pass
+                    except (TypeError, ValueError):
+                        continue
+                    if val >= filter_min and val <= 100:
+                        rewards.append((t, val))  # 保存 OCR对象 和 提取出的数值
+                    elif val > 100:
+                        self.log_debug(f"金额异常过大({val}万)，可能是OCR误识别，已过滤")
         return rewards, accept_btns, refresh_btn
 
     def detect_ticket_type(self, reward_obj, ticket_types, y_ceiling):

--- a/src/tasks/onetime/TakeDeliveryTask.py
+++ b/src/tasks/onetime/TakeDeliveryTask.py
@@ -60,7 +60,7 @@ class TakeDeliveryTask(BaseEfTask, TriggerTask):
                             rewards.append((t, val))  # 保存 OCR对象 和 提取出的数值
                         elif val > 100:
                             self.log_debug(f"金额异常过大({val}万)，可能是OCR误识别，已过滤")
-                    except:
+                    except Exception:
                         pass
         return rewards, accept_btns, refresh_btn
 


### PR DESCRIPTION
## 变更内容

针对 SonarCloud 存量报警（共 393 个）中**真实可修的缺陷/安全项**做修复，不涉及大规模重构类（认知复杂度 S3776、重复字符串 S1192 留待后续）。

### 修复项

| 规则 | 级别 | 位置 | 修复 |
|------|------|------|------|
| S5754 | CRITICAL | `TakeDeliveryTask.py:63`、`Mouse.py:374` | 裸 `except:` → `except Exception:` |
| S5797 | CRITICAL | `DeliveryTask.py:470` | 删除恒为 True 的死条件分支（`enable_delivery_area` 硬编码 True） |
| S7630 | BLOCKER | `smoke-tags.yml:106` | `inputs.wait_seconds` 直接拼入 run 块的脚本注入，改经 `env` 传递 |
| S6729 | CRITICAL | `rotated_template.py:174/345`、`gray_bar_detector.py:89` | 单参数 `np.where` → `np.nonzero`（语义一致，性能更明确） |
| S4423 | CRITICAL | `email_service.py:288` | 显式 `ssl_context.minimum_version = TLSv1_2` |

### 未修复项（误报/重构类，说明）

- **S930**（screenshot_sidecar.py:80）：`ImageFont.load_default(size=30)` 在 Pillow ≥ 10.1 合法，误报
- **S5655**（login_mixin.py:64/69）：`click_text` 接受正则 Pattern，传 `re.compile` 是既有用法，误报
- **S3776**（认知复杂度 ×69）、**S1192**（重复字符串 ×30）、**S3516**（恒返回值 ×8）等为历史遗留重构项，单 PR 处理风险高，另行跟进

## 测试

- 完整测试套件 294 个全部通过（5 skipped）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 邮件发送现强制使用 TLS 1.2 或更高版本，提升通信安全性。
  - 优化图像检测与模板匹配中的坐标处理，保持识别流程稳定。
  - 简化配送任务的票券类型处理逻辑。

- **Bug 修复**
  - 改进窗口恢复时的异常处理，避免忽略非标准异常。
  - 优化取货金额 OCR 结果处理，转换失败时可跳过异常数据并继续执行。
  - 调整冒烟测试参数传递方式，确保测试流程稳定运行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->