### PR TITLE
feat: auto-release 改用自定义 GitHub App token 创建 tag

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -96,7 +96,8 @@ jobs:
         if: steps.check.outputs.changed == 'true'
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ secrets.RELEASE_APP_ID }}
+          # App ID 是公开信息，放明文 variable 即可（Settings → Variables）
+          app-id: ${{ vars.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           # 仅给本仓库安装的 release bot 发 token
           owner: AliceJump

--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -91,16 +91,27 @@ jobs:
           fi
           echo "next=$next" >> "$GITHUB_OUTPUT"
 
+      - name: Generate GitHub App token for tag creation
+        id: app-token
+        if: steps.check.outputs.changed == 'true'
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+          # 仅给本仓库安装的 release bot 发 token
+          owner: AliceJump
+          repositories: ok-end-field
+
       - name: Create and push version tag
         if: steps.check.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           next="${{ steps.version.outputs.next }}"
           target="${{ steps.check.outputs.latest_commit }}"
-          git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git config user.name "alicejump-release-bot[bot]"
+          git config user.email "alicejump-release-bot[bot]@users.noreply.github.com"
           # tag 必须指向关注路径最后一次修改的 commit（latest_commit），而不是 HEAD
           git tag -a "$next" "$target" -m "$next"
           git push origin "$next"


### PR DESCRIPTION
解决 tag ruleset（Restrict creations）下自动发版无法打 tag 的问题。

## 背景
- 新建 ruleset「tag-create-restricted」：v* tag 仅限豁免者创建
- 内置 \GITHUB_TOKEN\ 代表 \github-actions[bot]\，**无法**加入 ruleset 豁免列表（GitHub 官方限制，API 报 \must be part of the ruleset source or owner organization\）
- 故 auto-release 打 tag 会被 ruleset 拦截

## 方案
- 新建自定义 GitHub App \licejump-release-bot\（App ID 4661219），已加入 tag-create-restricted 豁免列表
- auto-release.yml 用 \ctions/create-github-app-token\ 签发 App token 推送 tag

## 需要配置的 secrets
- \RELEASE_APP_ID\：4661219
- \RELEASE_APP_PRIVATE_KEY\：App 私钥 .pem 全文

## 验证
- 待 secrets 配置后手动触发 workflow_dispatch 验证

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **发布**
  * 优化自动发布流程：检测到变更时可自动创建发布标签。
  * 使用专用发布机器人身份执行标签创建，提升发布流程的稳定性与可追溯性。
  * 改进发布授权机制，确保自动创建标签时具备适当的访问权限。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->