### PR TITLE
fix: ruleset 下工作流适配——auto-release App token 认证 + 直推改走 PR

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -22,6 +22,8 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          # 不持久化 github.token，避免 git push 仍以 github-actions[bot] 认证
+          persist-credentials: false
 
       - name: Check changes in deploy.txt paths since last tag
         id: check
@@ -106,7 +108,7 @@ jobs:
       - name: Create and push version tag
         if: steps.check.outputs.changed == 'true'
         env:
-          GH_TOKEN: ${{ steps.app-token.outputs.token }}
+          APP_TOKEN: ${{ steps.app-token.outputs.token }}
         run: |
           set -euo pipefail
           next="${{ steps.version.outputs.next }}"
@@ -115,21 +117,9 @@ jobs:
           git config user.email "alicejump-release-bot[bot]@users.noreply.github.com"
           # tag 必须指向关注路径最后一次修改的 commit（latest_commit），而不是 HEAD
           git tag -a "$next" "$target" -m "$next"
-          git push origin "$next"
+          # 显式用 App token 认证推送（checkout 已 persist-credentials: false，
+          # 若直接 git push origin 会因无凭据失败），App token 在 tag ruleset 豁免列表中
+          git push "https://x-access-token:${APP_TOKEN}@github.com/${GITHUB_REPOSITORY}.git" "$next"
           echo "Released $next -> $target"
-
-      - name: Trigger Build via repository_dispatch
-        if: steps.check.outputs.changed == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          next="${{ steps.version.outputs.next }}"
-          # GITHUB_TOKEN 推送的 tag 不会触发 push 事件（官方限制），
-          # 改用 repository_dispatch（GITHUB_TOKEN 可触发的事件之一）通知 Build 构建该 tag
-          curl -sS -X POST \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            -H "Accept: application/vnd.github+json" \
-            "https://api.github.com/repos/${{ github.repository }}/dispatches" \
-            -d "{\"event_type\":\"auto-release\",\"client_payload\":{\"tag\":\"$next\"}}"
-          echo "Dispatched build for $next"
+          # App token 推送的 tag 会触发 build.yml 的 push 事件（GITHUB_TOKEN 不会，这是
+          # 之前用 repository_dispatch 的原因），因此不再需要手动 dispatch

--- a/.github/workflows/download_stats.yml
+++ b/.github/workflows/download_stats.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 jobs:
   build:
@@ -33,7 +34,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: commit
+      - name: commit to branch
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com
@@ -41,6 +42,27 @@ jobs:
           git add assets/downloads.svg
 
           if ! git diff --cached --quiet; then
+            git checkout -b chore/update-download-stats
             git commit -m "update download stats"
-            git push
+          fi
+
+      - name: push branch and open PR
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH="chore/update-download-stats"
+          if ! git rev-parse --verify "$BRANCH" >/dev/null 2>&1; then
+            echo "No changes; branch not created."
+            exit 0
+          fi
+          git push -f origin "$BRANCH"
+          if gh pr view "$BRANCH" --json number --jq '.number' >/dev/null 2>&1; then
+            gh pr edit "$BRANCH" --title "chore: update download stats" --body "由 download_stats 工作流自动生成的下载统计更新。"
+            echo "Updated existing PR for $BRANCH"
+          else
+            gh pr create --base master --head "$BRANCH" \
+              --title "chore: update download stats" \
+              --body "由 download_stats 工作流自动生成的下载统计更新。"
+            echo "Created new PR for $BRANCH"
           fi

--- a/.github/workflows/update-endfield-map-data.yml
+++ b/.github/workflows/update-endfield-map-data.yml
@@ -8,6 +8,7 @@ on:
 
 permissions:
   contents: write
+  pull-requests: write
 
 concurrency:
   group: update-endfield-map
@@ -130,7 +131,7 @@ jobs:
           print("Validation passed.")
           PY
 
-      - name: Commit
+      - name: Commit to branch
         if: steps.schedule.outputs.run == 'true'
         run: |
           git config user.name "github-actions[bot]"
@@ -143,9 +144,23 @@ jobs:
             exit 0
           fi
 
+          git checkout -b chore/update-map-data
           git commit -m "chore(map): update endfield map data"
 
-      - name: Push
+      - name: Push branch and open PR
         if: steps.schedule.outputs.run == 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          git push
+          set -euo pipefail
+          BRANCH="chore/update-map-data"
+          git push -f origin "$BRANCH"
+          if gh pr view "$BRANCH" --json number --jq '.number' >/dev/null 2>&1; then
+            gh pr edit "$BRANCH" --title "chore(map): 更新地图数据" --body "由 update-endfield-map-data 工作流自动生成的地图数据更新。"
+            echo "Updated existing PR for $BRANCH"
+          else
+            gh pr create --base master --head "$BRANCH" \
+              --title "chore(map): 更新地图数据" \
+              --body "由 update-endfield-map-data 工作流自动生成的地图数据更新。"
+            echo "Created new PR for $BRANCH"
+          fi


### PR DESCRIPTION
修复 master ruleset 启用后受影响的 3 个工作流。

## 背景
- master ruleset 启用 `pull_request` 规则（无豁免），`github-actions[bot]` 无法加入豁免列表，直推 master 会被拦截
- CodeRabbit 在 #195 指出 auto-release 的 App token 推送认证实际未生效

## 修复
1. **auto-release**（推 tag）
   - checkout 加 `persist-credentials: false`（不持久化 github.token）
   - `git push` 显式用 App token（`x-access-token`）认证
   - App token 推送 tag 会触发 build.yml 的 push 事件，删除 repository_dispatch 避免重复构建

2. **update-endfield-map-data**（原直推 master）
   - 改为 commit 到 `chore/update-map-data` 分支 → push → `gh pr create`，已有 PR 则更新
   - 补 `pull-requests: write` 权限

3. **download_stats**（原直推 master）
   - 改为 commit 到 `chore/update-download-stats` 分支 → push → `gh pr create`，已有 PR 则更新
   - 补 `pull-requests: write` 权限

## 注意
- GITHUB_TOKEN 创建的 PR 会触发 CI，但需人工审批才运行（GitHub 官方行为）
- 可触发 workflow_dispatch 实测验证

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **修复**
  * 改进自动发布流程的身份验证与标签推送机制。
  * 发布标签后可通过推送事件自动触发构建，提升发布流程的可靠性。

* **自动化改进**
  * 下载统计更新将通过专用分支和拉取请求提交，避免直接推送。
  * 地图数据更新将自动创建或更新拉取请求，便于审核与合并。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->