### PR TITLE
ci: 自动更新工作流启用 auto-merge

### DIFF
--- a/.github/workflows/download_stats.yml
+++ b/.github/workflows/download_stats.yml
@@ -66,3 +66,8 @@ jobs:
               --body "由 download_stats 工作流自动生成的下载统计更新。"
             echo "Created new PR for $BRANCH"
           fi
+          # 启用 auto-merge：checks 通过后自动 squash 合并（master ruleset approval=0）
+          gh pr merge "$BRANCH" --auto --squash --delete-branch \
+            --subject "chore: update download stats" \
+            --body "由 download_stats 工作流自动生成的下载统计更新。"
+          echo "Auto-merge enabled for $BRANCH"

--- a/.github/workflows/update-endfield-map-data.yml
+++ b/.github/workflows/update-endfield-map-data.yml
@@ -164,3 +164,9 @@ jobs:
               --body "由 update-endfield-map-data 工作流自动生成的地图数据更新。"
             echo "Created new PR for $BRANCH"
           fi
+          # 启用 auto-merge：校验已在 PR 创建前完成（Validate data 步骤），
+          # checks 通过后自动 squash 合并（master ruleset approval=0，squash 允许）
+          gh pr merge "$BRANCH" --auto --squash --delete-branch \
+            --subject "chore(map): 更新地图数据" \
+            --body "由 update-endfield-map-data 工作流自动生成的地图数据更新。"
+          echo "Auto-merge enabled for $BRANCH"


### PR DESCRIPTION
自动更新工作流（update-endfield-map-data / download_stats）创建/更新 PR 后启用 auto-merge。

## 改动
- 两个工作流在 `Push branch and open PR` 步骤末尾调用 `gh pr merge --auto --squash --delete-branch`
- checks 通过后自动 squash 合并，无需人工操作
- master ruleset 为 `required_approving_review_count: 0` 且允许 squash，auto-merge 可行（已在 PR #204 用个人 token 验证）

## 说明
- 地图数据/下载统计更新已由 `Validate data` 步骤校验（仅 map-data），合并安全
- 若 auto-merge 被 ruleset 拒绝，会回退为普通 PR 待人工合并（步骤会报错但不影响 PR 创建）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **自动化改进**
  - 下载统计更新和地图数据更新的 PR 在检查通过后可自动采用 squash 方式合并。
  - 合并完成后自动删除源分支，并统一设置合并提交标题和正文。
  - 新增自动合并状态日志，便于查看流程执行情况。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->