### PR TITLE
ci: 数据更新每次新建唯一分支+PR

### DIFF
--- a/.github/workflows/download_stats.yml
+++ b/.github/workflows/download_stats.yml
@@ -42,30 +42,24 @@ jobs:
           git add assets/downloads.svg
 
           if ! git diff --cached --quiet; then
-            git checkout -b chore/update-download-stats
+            BRANCH="chore/update-download-stats-$(date -u +%Y%m%d%H%M%S)"
+            echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+            git checkout -b "$BRANCH"
             git commit -m "update download stats"
           fi
 
       - name: push branch and open PR
+        if: steps.commit.outputs.branch != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          BRANCH="chore/update-download-stats"
-          if ! git rev-parse --verify "$BRANCH" >/dev/null 2>&1; then
-            echo "No changes; branch not created."
-            exit 0
-          fi
-          git push -f origin "$BRANCH"
-          if gh pr view "$BRANCH" --json number --jq '.number' >/dev/null 2>&1; then
-            gh pr edit "$BRANCH" --title "chore: update download stats" --body "由 download_stats 工作流自动生成的下载统计更新。"
-            echo "Updated existing PR for $BRANCH"
-          else
-            gh pr create --base master --head "$BRANCH" \
-              --title "chore: update download stats" \
-              --body "由 download_stats 工作流自动生成的下载统计更新。"
-            echo "Created new PR for $BRANCH"
-          fi
+          BRANCH="${{ steps.commit.outputs.branch }}"
+          git push -u origin "$BRANCH"
+          gh pr create --base master --head "$BRANCH" \
+            --title "chore: update download stats" \
+            --body "由 download_stats 工作流自动生成的下载统计更新。"
+          echo "Created new PR for $BRANCH"
           # 启用 auto-merge：checks 通过后自动 squash 合并（master ruleset approval=0）
           gh pr merge "$BRANCH" --auto --squash --delete-branch \
             --subject "chore: update download stats" \

--- a/.github/workflows/update-endfield-map-data.yml
+++ b/.github/workflows/update-endfield-map-data.yml
@@ -144,26 +144,23 @@ jobs:
             exit 0
           fi
 
-          git checkout -b chore/update-map-data
+          BRANCH="chore/update-map-data-$(date -u +%Y%m%d%H%M%S)"
+          echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+          git checkout -b "$BRANCH"
           git commit -m "chore(map): update endfield map data"
 
       - name: Push branch and open PR
-        if: steps.schedule.outputs.run == 'true'
+        if: steps.commit.outputs.branch != ''
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          BRANCH="chore/update-map-data"
-          git push -f origin "$BRANCH"
-          if gh pr view "$BRANCH" --json number --jq '.number' >/dev/null 2>&1; then
-            gh pr edit "$BRANCH" --title "chore(map): 更新地图数据" --body "由 update-endfield-map-data 工作流自动生成的地图数据更新。"
-            echo "Updated existing PR for $BRANCH"
-          else
-            gh pr create --base master --head "$BRANCH" \
-              --title "chore(map): 更新地图数据" \
-              --body "由 update-endfield-map-data 工作流自动生成的地图数据更新。"
-            echo "Created new PR for $BRANCH"
-          fi
+          BRANCH="${{ steps.commit.outputs.branch }}"
+          git push -u origin "$BRANCH"
+          gh pr create --base master --head "$BRANCH" \
+            --title "chore(map): 更新地图数据" \
+            --body "由 update-endfield-map-data 工作流自动生成的地图数据更新。"
+          echo "Created new PR for $BRANCH"
           # 启用 auto-merge：校验已在 PR 创建前完成（Validate data 步骤），
           # checks 通过后自动 squash 合并（master ruleset approval=0，squash 允许）
           gh pr merge "$BRANCH" --auto --squash --delete-branch \


### PR DESCRIPTION
数据更新工作流改为「每次新建唯一分支 + 新建 PR」，去掉 `gh pr edit` 复用逻辑。

## 问题
- 原逻辑固定分支 `chore/update-map-data`，复用同分支 + `gh pr edit` 更新已有 PR
- 无数据变更时 Commit 步骤 `exit 0` 但 PR 步骤仍执行：push 旧分支、误编辑已合并的 PR
- 出现 "Updated existing PR" 与新建逻辑混淆

## 改动
- 分支名带时间戳（如 `chore/update-map-data-20260821000000`），每次有新数据新建独立分支 + 独立 PR
- 无变更时 Commit 步骤不输出 `branch`，PR 步骤用 `if: steps.commit.outputs.branch != ''` 直接跳过
- 保留 auto-merge：checks 通过后自动 squash 合并 + 删分支
- 两个工作流同步修改：update-endfield-map-data / download_stats

## 验证
- YAML 语法检查通过
- 无变更路径：Commit 输出为空 → PR 步骤跳过（不再误操作）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **自动化改进**
  - 数据更新任务现在会按 UTC 时间生成唯一分支，并自动推送更改、创建新的拉取请求。
  - 移除固定分支和强制推送方式，降低自动更新相互覆盖的风险。
- **问题修复**
  - 修正自动提交与后续推送步骤之间的分支信息传递，确保生成的分支能够被正确使用。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->