### PR TITLE
fix: commit 步骤补 id，修复 steps.commit.outputs.branch 引用失效

### DIFF
--- a/.github/workflows/download_stats.yml
+++ b/.github/workflows/download_stats.yml
@@ -35,6 +35,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: commit to branch
+        id: commit
         run: |
           git config user.name github-actions
           git config user.email github-actions@github.com

--- a/.github/workflows/update-endfield-map-data.yml
+++ b/.github/workflows/update-endfield-map-data.yml
@@ -132,6 +132,7 @@ jobs:
           PY
 
       - name: Commit to branch
+        id: commit
         if: steps.schedule.outputs.run == 'true'
         run: |
           git config user.name "github-actions[bot]"


### PR DESCRIPTION
修复 commit 步骤缺少 `id: commit` 的问题。

## 背景
PR #208 引入 `steps.commit.outputs.branch != ''` 作为 PR 步骤的跳过条件，
但 commit 步骤未定义 `id: commit`。GitHub Actions 中引用 step 输出必须
用 `steps.<id>.outputs.<name>`，没有 id 时 `steps.commit.outputs.branch`
解析为空字符串 → PR 步骤永远被跳过。

## 后果
即使有数据变更（生成新地图数据/下载统计），也**不会自动创建 PR、不会
auto-merge**。这正是定时更新"没提 PR 没合并"的根因之一。

## 修复
- update-endfield-map-data.yml / download_stats.yml 的 commit 步骤补 `id: commit`
- 由 CodeRabbit review（PR #208）发现

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化自动化数据更新流程，可根据提交结果自动判断是否推送分支并创建拉取请求。
  * 改进分支名称传递，提升后续工作流步骤的执行可靠性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->