### PR TITLE
fix: 送货任务 OCR 等待超时 60s 延长至 120s

### DIFF
--- a/src/tasks/onetime/DeliveryTask.py
+++ b/src/tasks/onetime/DeliveryTask.py
@@ -536,7 +536,7 @@ class DeliveryTask(AccountMixin, ZipLineMixin, MapMixin):
         Returns:
             bool: 成功返回True，失败返回False
         """
-        if result := self.wait_ocr(match=self.lang.DeliveryTask.k_b0e3a2da, box=self.box.bottom_right, time_out=60, log=True):
+        if result := self.wait_ocr(match=self.lang.DeliveryTask.k_b0e3a2da, box=self.box.bottom_right, time_out=120, log=True):
             if self.wait_ocr(match=self.lang.DeliveryTask.k_96b876e3, box=self.box.top_left, time_out=2, log=True):
                 self.press_key("tab")
                 self.wait_until(


### PR DESCRIPTION
## 概述

送货任务中等待送达确认弹窗的 OCR 匹配（`k_b0e3a2da`）超时从 60 秒延长至 120 秒，减少慢速加载场景下的误判失败。

## 验证

- `uv run python -m unittest discover -s tests`：297 通过（5 跳过）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 延长等待送货点界面识别的超时时间，减少因界面加载较慢导致的任务失败。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->