### PR TITLE
feat: 传送后寻找滑索架按钮增加踱步与前后移动搜索兜底

### DIFF
--- a/src/tasks/onetime/DeliveryTask.py
+++ b/src/tasks/onetime/DeliveryTask.py
@@ -559,18 +559,21 @@ class DeliveryTask(AccountMixin, ZipLineMixin, MapMixin):
                 return found
             self.sleep(0.1)
 
+        elapsed = self.active_time() - start
+        if total_time_out - elapsed <= 0:  # 严格遵守总截止时间：剩余不足时不再进入移动搜索
+            self.log_info("总等待时间已耗尽，仍未找到登上滑索架")
+            return None
+
         # 切换步行模式：踱步与前后移动都用走路，避免奔跑错过交互按钮
         self.press_key("ctrl")  # 确认使用send_key：ctrl为奔跑切换键，不属于游戏可配置热键
         try:
             # 阶段二：WASD 踱步寻找（参考 nav 目标不稳定时的做法），最多持续约 10 秒
             self.log_info("短时间内未找到登上滑索架，可能被其他设备遮挡，切换步行开始踱步寻找（最长 10 秒）")
-            elapsed = self.active_time() - start
-            strafe_budget = min(10.0, max(1.0, total_time_out - elapsed))
             found = self.strafe_search(
                 check,
                 passes=None,  # 不限轮数，持续踱步直到找到或阶段时限
                 duration=0.2,  # 每个方向轻移 0.2 秒，避免走远
-                time_out=strafe_budget,
+                time_out=min(10.0, total_time_out - elapsed),
             )
             if found:
                 self.log_info("踱步寻找过程中找到登上滑索架")
@@ -587,7 +590,7 @@ class DeliveryTask(AccountMixin, ZipLineMixin, MapMixin):
                 passes=None,
                 duration=0.2,
                 keys=("w", "s"),  # 仅前后移动
-                time_out=max(1.0, remaining),
+                time_out=remaining,
             )
             if found:
                 self.log_info("前后移动寻找过程中找到登上滑索架")

--- a/src/tasks/onetime/DeliveryTask.py
+++ b/src/tasks/onetime/DeliveryTask.py
@@ -527,6 +527,51 @@ class DeliveryTask(AccountMixin, ZipLineMixin, MapMixin):
                 self.log_info("警告: 尚未定位到刷新按钮位置，无法刷新，重试...")
                 self.sleep(1.0)
 
+    def _find_zip_line_board_button(self, direct_wait=5.0, total_time_out=60.0):
+        """传送落地后确保处于主界面，再寻找「登上滑索架」交互按钮。
+
+        先在主界面直接查找按钮约 direct_wait 秒；若附近其他设备过近遮挡
+        滑索架导致交互按钮不出现，则参考 navigate_until_target 目标不稳定
+        时的做法（WASD 小幅度踱步搜索），边踱步边找直到总超时。
+
+        Args:
+            direct_wait: 直接原地查找的时长（秒）。
+            total_time_out: 含直接查找在内的总超时（秒）。
+
+        Returns:
+            Box | None: 找到的「登上滑索架」按钮位置；超时返回 None。
+        """
+        self.ensure_main()  # 传送后先确保回到主界面再尝试登滑索架
+        match = self.lang.DeliveryTask.k_b0e3a2da  # 「登上滑索架」按钮 OCR 文本
+        box = self.box.bottom_right  # 交互按钮固定出现在右下角提示区
+        start = self.active_time()
+
+        def check():
+            frame = self.next_frame()  # 移动或等待后必须取新帧再识别
+            results = self.ocr(match=match, box=box, frame=frame, log=True)
+            return results[0] if results else None  # 命中返回按钮位置
+
+        # 阶段一：直接原地查找一小段时间（正常情况下按钮很快出现）
+        while self.active_time() - start < direct_wait:
+            if found := check():
+                return found
+            self.sleep(0.1)
+
+        # 阶段二：踱步寻找（WASD 小幅度移动，参考 nav 目标不稳定时的做法）
+        self.log_info("短时间内未找到登上滑索架，可能被其他设备遮挡，开始踱步寻找")
+        remaining = total_time_out - (self.active_time() - start)
+        found = self.strafe_search(
+            check,
+            passes=None,  # 不限轮数，持续踱步直到找到或超时
+            duration=0.2,  # 每个方向轻移 0.2 秒，避免走远
+            time_out=max(1.0, remaining),
+        )
+        if found:
+            self.log_info("踱步寻找过程中找到登上滑索架")
+        else:
+            self.log_info("踱步寻找超时，仍未找到登上滑索架")
+        return found
+
     def to_storage_point_and_back_zip_line(self, only_zip_line=False):
         """从仓储点出发，乘坐滑索到送货点
 
@@ -536,7 +581,8 @@ class DeliveryTask(AccountMixin, ZipLineMixin, MapMixin):
         Returns:
             bool: 成功返回True，失败返回False
         """
-        if result := self.wait_ocr(match=self.lang.DeliveryTask.k_b0e3a2da, box=self.box.bottom_right, time_out=120, log=True):
+        result = self._find_zip_line_board_button(total_time_out=120)  # 主界面确认 + 找登滑索架按钮（含踱步兜底），总超时沿用 120s
+        if result:
             if self.wait_ocr(match=self.lang.DeliveryTask.k_96b876e3, box=self.box.top_left, time_out=2, log=True):
                 self.press_key("tab")
                 self.wait_until(
@@ -547,7 +593,7 @@ class DeliveryTask(AccountMixin, ZipLineMixin, MapMixin):
                     time_out=2,
                     raise_if_not_found=False,
                 )
-            self.click_with_alt(result[0], after_sleep=2)
+            self.click_with_alt(result, after_sleep=2)  # result 已是单个按钮 Box（踱步搜索返回值）
             to_delivery_point_key = self._resolve_to_delivery_point_config_key()
             if not to_delivery_point_key:
                 return False

--- a/src/tasks/onetime/DeliveryTask.py
+++ b/src/tasks/onetime/DeliveryTask.py
@@ -530,9 +530,11 @@ class DeliveryTask(AccountMixin, ZipLineMixin, MapMixin):
     def _find_zip_line_board_button(self, direct_wait=5.0, total_time_out=60.0):
         """传送落地后确保处于主界面，再寻找「登上滑索架」交互按钮。
 
-        先在主界面直接查找按钮约 direct_wait 秒；若附近其他设备过近遮挡
-        滑索架导致交互按钮不出现，则参考 navigate_until_target 目标不稳定
-        时的做法（WASD 小幅度踱步搜索），边踱步边找直到总超时。
+        分三个阶段：
+        1. 直接原地查找约 ``direct_wait`` 秒；
+        2. 未找到则切换步行模式做 WASD 小幅度踱步搜索，最多约 10 秒；
+        3. 仍未找到则改为仅 W/S 前后移动继续搜索，直到总超时。
+        移动全程保持步行而非奔跑（ctrl 切换），结束后恢复奔跑模式。
 
         Args:
             direct_wait: 直接原地查找的时长（秒）。
@@ -557,20 +559,44 @@ class DeliveryTask(AccountMixin, ZipLineMixin, MapMixin):
                 return found
             self.sleep(0.1)
 
-        # 阶段二：踱步寻找（WASD 小幅度移动，参考 nav 目标不稳定时的做法）
-        self.log_info("短时间内未找到登上滑索架，可能被其他设备遮挡，开始踱步寻找")
-        remaining = total_time_out - (self.active_time() - start)
-        found = self.strafe_search(
-            check,
-            passes=None,  # 不限轮数，持续踱步直到找到或超时
-            duration=0.2,  # 每个方向轻移 0.2 秒，避免走远
-            time_out=max(1.0, remaining),
-        )
-        if found:
-            self.log_info("踱步寻找过程中找到登上滑索架")
-        else:
-            self.log_info("踱步寻找超时，仍未找到登上滑索架")
-        return found
+        # 切换步行模式：踱步与前后移动都用走路，避免奔跑错过交互按钮
+        self.press_key("ctrl")  # 确认使用send_key：ctrl为奔跑切换键，不属于游戏可配置热键
+        try:
+            # 阶段二：WASD 踱步寻找（参考 nav 目标不稳定时的做法），最多持续约 10 秒
+            self.log_info("短时间内未找到登上滑索架，可能被其他设备遮挡，切换步行开始踱步寻找（最长 10 秒）")
+            elapsed = self.active_time() - start
+            strafe_budget = min(10.0, max(1.0, total_time_out - elapsed))
+            found = self.strafe_search(
+                check,
+                passes=None,  # 不限轮数，持续踱步直到找到或阶段时限
+                duration=0.2,  # 每个方向轻移 0.2 秒，避免走远
+                time_out=strafe_budget,
+            )
+            if found:
+                self.log_info("踱步寻找过程中找到登上滑索架")
+                return found
+
+            # 阶段三：改为仅 W/S 前后移动继续找，直到总超时
+            remaining = total_time_out - (self.active_time() - start)
+            if remaining <= 0:
+                self.log_info("踱步超时，仍未找到登上滑索架")
+                return None
+            self.log_info("踱步仍未找到登上滑索架，改为仅 W/S 前后移动继续寻找")
+            found = self.strafe_search(
+                check,
+                passes=None,
+                duration=0.2,
+                keys=("w", "s"),  # 仅前后移动
+                time_out=max(1.0, remaining),
+            )
+            if found:
+                self.log_info("前后移动寻找过程中找到登上滑索架")
+                return found
+            self.log_info("前后移动超时，仍未找到登上滑索架")
+            return None
+        finally:
+            self.press_key("ctrl", after_sleep=0.01)  # 结束后恢复奔跑模式（与导航结束时处理一致）
+            self.log_info("恢复奔跑模式")
 
     def to_storage_point_and_back_zip_line(self, only_zip_line=False):
         """从仓储点出发，乘坐滑索到送货点

--- a/src/tasks/onetime/DeliveryTask.py
+++ b/src/tasks/onetime/DeliveryTask.py
@@ -573,13 +573,14 @@ class DeliveryTask(AccountMixin, ZipLineMixin, MapMixin):
                 check,
                 passes=None,  # 不限轮数，持续踱步直到找到或阶段时限
                 duration=0.2,  # 每个方向轻移 0.2 秒，避免走远
+                keys=("s", "w", "a", "d"),  # 后退优先：落点常越过滑索架，后退最容易重新看到
                 time_out=min(10.0, total_time_out - elapsed),
             )
             if found:
                 self.log_info("踱步寻找过程中找到登上滑索架")
                 return found
 
-            # 阶段三：改为仅 W/S 前后移动继续找，直到总超时
+            # 阶段三：改为仅前后移动继续找，直到总超时
             remaining = total_time_out - (self.active_time() - start)
             if remaining <= 0:
                 self.log_info("踱步超时，仍未找到登上滑索架")
@@ -589,7 +590,7 @@ class DeliveryTask(AccountMixin, ZipLineMixin, MapMixin):
                 check,
                 passes=None,
                 duration=0.2,
-                keys=("w", "s"),  # 仅前后移动
+                keys=("s", "w"),  # 仅前后移动，同样后退优先
                 time_out=remaining,
             )
             if found:

--- a/src/tasks/onetime/DeliveryTask.py
+++ b/src/tasks/onetime/DeliveryTask.py
@@ -547,20 +547,22 @@ class DeliveryTask(AccountMixin, ZipLineMixin, MapMixin):
         match = self.lang.DeliveryTask.k_b0e3a2da  # 「登上滑索架」按钮 OCR 文本
         box = self.box.bottom_right  # 交互按钮固定出现在右下角提示区
         start = self.active_time()
+        deadline = start + max(0.0, total_time_out)  # 统一总截止时间
 
         def check():
             frame = self.next_frame()  # 移动或等待后必须取新帧再识别
             results = self.ocr(match=match, box=box, frame=frame, log=True)
             return results[0] if results else None  # 命中返回按钮位置
 
-        # 阶段一：直接原地查找一小段时间（正常情况下按钮很快出现）
-        while self.active_time() - start < direct_wait:
+        # 阶段一：直接原地查找一小段时间（正常情况下按钮很快出现），
+        # 但同样受总截止时间约束（direct_wait 大于剩余预算时提前截断）
+        while self.active_time() < min(start + direct_wait, deadline):
             if found := check():
                 return found
             self.sleep(0.1)
 
-        elapsed = self.active_time() - start
-        if total_time_out - elapsed <= 0:  # 严格遵守总截止时间：剩余不足时不再进入移动搜索
+        remaining = deadline - self.active_time()
+        if remaining <= 0:  # 严格遵守总截止时间：剩余不足时不再进入移动搜索
             self.log_info("总等待时间已耗尽，仍未找到登上滑索架")
             return None
 
@@ -574,14 +576,14 @@ class DeliveryTask(AccountMixin, ZipLineMixin, MapMixin):
                 passes=None,  # 不限轮数，持续踱步直到找到或阶段时限
                 duration=0.2,  # 每个方向轻移 0.2 秒，避免走远
                 keys=("s", "w", "a", "d"),  # 后退优先：落点常越过滑索架，后退最容易重新看到
-                time_out=min(10.0, total_time_out - elapsed),
+                time_out=min(10.0, remaining),
             )
             if found:
                 self.log_info("踱步寻找过程中找到登上滑索架")
                 return found
 
             # 阶段三：改为仅前后移动继续找，直到总超时
-            remaining = total_time_out - (self.active_time() - start)
+            remaining = deadline - self.active_time()
             if remaining <= 0:
                 self.log_info("踱步超时，仍未找到登上滑索架")
                 return None

--- a/tests/TestFindZipLineBoardButton.py
+++ b/tests/TestFindZipLineBoardButton.py
@@ -1,6 +1,5 @@
 # -*- coding: utf-8 -*-
-"""验证传送后寻找「登上滑索架」按钮的两阶段逻辑（直接查找 + 踱步搜索）。"""
-import time
+"""验证传送后寻找「登上滑索架」按钮的三阶段逻辑（直接查找 + 踱步 + 前后移动）。"""
 import unittest
 from types import SimpleNamespace
 
@@ -11,19 +10,26 @@ class _FakeBox:
     """模拟 OCR 命中的按钮 Box。"""
 
 
-def _make_stub(ocr_results, strafe_result="not-called"):
-    """构造仅包含 _find_zip_line_board_button 所需接口的桩对象。"""
+def _make_stub(ocr_results, strafe_results=None, advance_per_strafe=None):
+    """构造仅包含 _find_zip_line_board_button 所需接口的桩对象。
+
+    strafe_results: 每次 strafe_search 调用依次返回的值；None 表示该次返回未命中。
+    advance_per_strafe: 每次踱步调用后时钟前进的秒数（模拟搜索真实耗时）。
+    """
     stub = SimpleNamespace()
     stub._ocr_results = list(ocr_results)
-    stub._strafe_result = strafe_result
+    stub._strafe_results = list(strafe_results or [])
     stub.strafe_calls = []
+    stub.ctrl_calls = []
     stub.log_lines = []
     stub.lang = SimpleNamespace(
         DeliveryTask=SimpleNamespace(k_b0e3a2da="登上滑索架"))
     stub.box = SimpleNamespace(bottom_right="bottom_right")
     stub.ensure_main_calls = []
     stub.ensure_main = lambda *a, **kw: stub.ensure_main_calls.append(kw)
-    stub.active_time = time.monotonic
+    clock = {"t": 0.0}
+    stub.clock = clock
+    stub.active_time = lambda: clock["t"]
     stub.next_frame = lambda: "frame"
 
     def _ocr(**kwargs):
@@ -33,13 +39,22 @@ def _make_stub(ocr_results, strafe_result="not-called"):
         return []
 
     stub.ocr = _ocr
-    stub.sleep = lambda *a, **kw: None
+
+    def _sleep(sec=0):
+        clock["t"] += sec if isinstance(sec, (int, float)) else 0  # 桩时钟随等待前进
+
+    stub.sleep = _sleep
     stub.log_info = lambda msg: stub.log_lines.append(msg)
+    stub.press_key = lambda key, *a, **kw: stub.ctrl_calls.append(key)
 
     def _strafe(check, passes=None, duration=0.2, keys=("w", "a", "s", "d"),
                 time_out=-1):
-        stub.strafe_calls.append(time_out)
-        return stub._strafe_result
+        stub.strafe_calls.append({"keys": keys, "time_out": time_out})
+        if advance_per_strafe is not None:
+            clock["t"] += advance_per_strafe  # 模拟踱步搜索真实耗时
+        if stub._strafe_results:
+            return stub._strafe_results.pop(0)
+        return None
 
     stub.strafe_search = _strafe
     return stub
@@ -47,7 +62,7 @@ def _make_stub(ocr_results, strafe_result="not-called"):
 
 class TestFindZipLineBoardButton(unittest.TestCase):
     def test_direct_hit(self):
-        """阶段一直接找到按钮：不进入踱步搜索。"""
+        """阶段一直接找到按钮：不进入踱步搜索，也不切换步行。"""
         box = _FakeBox()
         stub = _make_stub(ocr_results=[None, box])
         result = DeliveryTask._find_zip_line_board_button(
@@ -55,25 +70,42 @@ class TestFindZipLineBoardButton(unittest.TestCase):
         self.assertIs(result, box)
         self.assertEqual(len(stub.ensure_main_calls), 1)  # 先确认主界面
         self.assertEqual(stub.strafe_calls, [])  # 未触发踱步
+        self.assertEqual(stub.ctrl_calls, [])  # 未切换步行/奔跑
 
     def test_strafe_hit_after_direct_miss(self):
-        """阶段一找不到时进入踱步搜索并命中。"""
+        """阶段一找不到时进入 WASD 踱步搜索并命中，时限不超过 10 秒。"""
         box = _FakeBox()
-        stub = _make_stub(ocr_results=[], strafe_result=box)
+        stub = _make_stub(ocr_results=[], strafe_results=[box])
         result = DeliveryTask._find_zip_line_board_button(
             stub, direct_wait=0.02, total_time_out=30.0)
         self.assertIs(result, box)
-        self.assertEqual(len(stub.strafe_calls), 1)  # 进入踱步一次
-        self.assertGreaterEqual(stub.strafe_calls[0], 1.0)  # 踱步时限为剩余时间
+        self.assertEqual(len(stub.strafe_calls), 1)  # 仅进入踱步一次
+        self.assertLessEqual(stub.strafe_calls[0]["time_out"], 10.0)  # 踱步最多 10 秒
+        self.assertEqual(stub.strafe_calls[0]["keys"], ("w", "a", "s", "d"))
+        self.assertEqual(stub.ctrl_calls, ["ctrl", "ctrl"])  # 切步行 + 恢复奔跑
         self.assertTrue(any("踱步" in msg for msg in stub.log_lines))
 
+    def test_ws_fallback_after_strafe_timeout(self):
+        """踱步超时后改用仅 W/S 前后移动继续找，命中后恢复奔跑。"""
+        box = _FakeBox()
+        stub = _make_stub(ocr_results=[], strafe_results=[None, box])
+        result = DeliveryTask._find_zip_line_board_button(
+            stub, direct_wait=0.02, total_time_out=60.0)
+        self.assertIs(result, box)
+        self.assertEqual(len(stub.strafe_calls), 2)  # 踱步 + 前后移动各一次
+        self.assertEqual(stub.strafe_calls[1]["keys"], ("w", "s"))  # 阶段三仅前后移动
+        self.assertGreaterEqual(stub.strafe_calls[1]["time_out"], 1.0)  # 用剩余时间继续找
+        self.assertEqual(stub.ctrl_calls, ["ctrl", "ctrl"])  # 结束恢复奔跑模式
+
     def test_timeout_returns_none(self):
-        """踱步超时仍未找到：返回 None 并记录超时日志。"""
-        stub = _make_stub(ocr_results=[], strafe_result=None)
+        """总超时仍未找到：返回 None 并记录超时日志。"""
+        stub = _make_stub(ocr_results=[], strafe_results=[None],
+                          advance_per_strafe=10.0)  # 踱步消耗掉全部预算
         result = DeliveryTask._find_zip_line_board_button(
             stub, direct_wait=0.01, total_time_out=0.03)
         self.assertIsNone(result)
         self.assertTrue(any("超时" in msg for msg in stub.log_lines))
+        self.assertEqual(len(stub.strafe_calls), 1)  # 总预算耗尽时不再进入阶段三
 
 
 if __name__ == "__main__":

--- a/tests/TestFindZipLineBoardButton.py
+++ b/tests/TestFindZipLineBoardButton.py
@@ -94,18 +94,30 @@ class TestFindZipLineBoardButton(unittest.TestCase):
         self.assertIs(result, box)
         self.assertEqual(len(stub.strafe_calls), 2)  # 踱步 + 前后移动各一次
         self.assertEqual(stub.strafe_calls[1]["keys"], ("w", "s"))  # 阶段三仅前后移动
-        self.assertGreaterEqual(stub.strafe_calls[1]["time_out"], 1.0)  # 用剩余时间继续找
+        # 阶段三时限为剩余时间：不超过总超时，且确实用掉了大部分预算
+        self.assertLessEqual(stub.strafe_calls[1]["time_out"], 60.0)
+        self.assertGreater(stub.strafe_calls[1]["time_out"], 55.0)
         self.assertEqual(stub.ctrl_calls, ["ctrl", "ctrl"])  # 结束恢复奔跑模式
 
     def test_timeout_returns_none(self):
         """总超时仍未找到：返回 None 并记录超时日志。"""
         stub = _make_stub(ocr_results=[], strafe_results=[None],
-                          advance_per_strafe=10.0)  # 踱步消耗掉全部预算
+                          advance_per_strafe=10.0)  # 踱步消耗掉全部剩余预算
         result = DeliveryTask._find_zip_line_board_button(
-            stub, direct_wait=0.01, total_time_out=0.03)
+            stub, direct_wait=0.01, total_time_out=5.0)
         self.assertIsNone(result)
         self.assertTrue(any("超时" in msg for msg in stub.log_lines))
-        self.assertEqual(len(stub.strafe_calls), 1)  # 总预算耗尽时不再进入阶段三
+        self.assertEqual(len(stub.strafe_calls), 1)  # 总预算耗尽时不进入阶段三
+        self.assertLessEqual(stub.strafe_calls[0]["time_out"], 5.0)  # 不超过总超时
+
+    def test_exhausted_before_strafe_returns_immediately(self):
+        """阶段一耗尽全部预算：直接返回 None，不切步行也不进入移动搜索。"""
+        stub = _make_stub(ocr_results=[])
+        result = DeliveryTask._find_zip_line_board_button(
+            stub, direct_wait=0.0, total_time_out=-1.0)
+        self.assertIsNone(result)
+        self.assertEqual(stub.strafe_calls, [])
+        self.assertEqual(stub.ctrl_calls, [])  # 未做任何模式切换
 
 
 if __name__ == "__main__":

--- a/tests/TestFindZipLineBoardButton.py
+++ b/tests/TestFindZipLineBoardButton.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+"""验证传送后寻找「登上滑索架」按钮的两阶段逻辑（直接查找 + 踱步搜索）。"""
+import time
+import unittest
+from types import SimpleNamespace
+
+from src.tasks.onetime.DeliveryTask import DeliveryTask
+
+
+class _FakeBox:
+    """模拟 OCR 命中的按钮 Box。"""
+
+
+def _make_stub(ocr_results, strafe_result="not-called"):
+    """构造仅包含 _find_zip_line_board_button 所需接口的桩对象。"""
+    stub = SimpleNamespace()
+    stub._ocr_results = list(ocr_results)
+    stub._strafe_result = strafe_result
+    stub.strafe_calls = []
+    stub.log_lines = []
+    stub.lang = SimpleNamespace(
+        DeliveryTask=SimpleNamespace(k_b0e3a2da="登上滑索架"))
+    stub.box = SimpleNamespace(bottom_right="bottom_right")
+    stub.ensure_main_calls = []
+    stub.ensure_main = lambda *a, **kw: stub.ensure_main_calls.append(kw)
+    stub.active_time = time.monotonic
+    stub.next_frame = lambda: "frame"
+
+    def _ocr(**kwargs):
+        if stub._ocr_results:
+            item = stub._ocr_results.pop(0)
+            return [item] if item else []
+        return []
+
+    stub.ocr = _ocr
+    stub.sleep = lambda *a, **kw: None
+    stub.log_info = lambda msg: stub.log_lines.append(msg)
+
+    def _strafe(check, passes=None, duration=0.2, keys=("w", "a", "s", "d"),
+                time_out=-1):
+        stub.strafe_calls.append(time_out)
+        return stub._strafe_result
+
+    stub.strafe_search = _strafe
+    return stub
+
+
+class TestFindZipLineBoardButton(unittest.TestCase):
+    def test_direct_hit(self):
+        """阶段一直接找到按钮：不进入踱步搜索。"""
+        box = _FakeBox()
+        stub = _make_stub(ocr_results=[None, box])
+        result = DeliveryTask._find_zip_line_board_button(
+            stub, direct_wait=5.0, total_time_out=60.0)
+        self.assertIs(result, box)
+        self.assertEqual(len(stub.ensure_main_calls), 1)  # 先确认主界面
+        self.assertEqual(stub.strafe_calls, [])  # 未触发踱步
+
+    def test_strafe_hit_after_direct_miss(self):
+        """阶段一找不到时进入踱步搜索并命中。"""
+        box = _FakeBox()
+        stub = _make_stub(ocr_results=[], strafe_result=box)
+        result = DeliveryTask._find_zip_line_board_button(
+            stub, direct_wait=0.02, total_time_out=30.0)
+        self.assertIs(result, box)
+        self.assertEqual(len(stub.strafe_calls), 1)  # 进入踱步一次
+        self.assertGreaterEqual(stub.strafe_calls[0], 1.0)  # 踱步时限为剩余时间
+        self.assertTrue(any("踱步" in msg for msg in stub.log_lines))
+
+    def test_timeout_returns_none(self):
+        """踱步超时仍未找到：返回 None 并记录超时日志。"""
+        stub = _make_stub(ocr_results=[], strafe_result=None)
+        result = DeliveryTask._find_zip_line_board_button(
+            stub, direct_wait=0.01, total_time_out=0.03)
+        self.assertIsNone(result)
+        self.assertTrue(any("超时" in msg for msg in stub.log_lines))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/TestFindZipLineBoardButton.py
+++ b/tests/TestFindZipLineBoardButton.py
@@ -111,13 +111,16 @@ class TestFindZipLineBoardButton(unittest.TestCase):
         self.assertLessEqual(stub.strafe_calls[0]["time_out"], 5.0)  # 不超过总超时
 
     def test_exhausted_before_strafe_returns_immediately(self):
-        """阶段一耗尽全部预算：直接返回 None，不切步行也不进入移动搜索。"""
+        """阶段一耗尽正数的短总预算：立即返回，不切步行也不进入移动搜索。"""
         stub = _make_stub(ocr_results=[])
         result = DeliveryTask._find_zip_line_board_button(
-            stub, direct_wait=0.0, total_time_out=-1.0)
+            stub, direct_wait=5.0, total_time_out=0.03)
         self.assertIsNone(result)
         self.assertEqual(stub.strafe_calls, [])
         self.assertEqual(stub.ctrl_calls, [])  # 未做任何模式切换
+        # 阶段一被总截止时间截断：未跑满 direct_wait
+        # （桩时钟按 sleep(0.1) 步进，留一个步长容差）
+        self.assertLessEqual(stub.clock["t"], 0.03 + 0.1)
 
 
 if __name__ == "__main__":

--- a/tests/TestFindZipLineBoardButton.py
+++ b/tests/TestFindZipLineBoardButton.py
@@ -47,7 +47,7 @@ def _make_stub(ocr_results, strafe_results=None, advance_per_strafe=None):
     stub.log_info = lambda msg: stub.log_lines.append(msg)
     stub.press_key = lambda key, *a, **kw: stub.ctrl_calls.append(key)
 
-    def _strafe(check, passes=None, duration=0.2, keys=("w", "a", "s", "d"),
+    def _strafe(check, passes=None, duration=0.2, keys=("s", "w", "a", "d"),
                 time_out=-1):
         stub.strafe_calls.append({"keys": keys, "time_out": time_out})
         if advance_per_strafe is not None:
@@ -81,7 +81,7 @@ class TestFindZipLineBoardButton(unittest.TestCase):
         self.assertIs(result, box)
         self.assertEqual(len(stub.strafe_calls), 1)  # 仅进入踱步一次
         self.assertLessEqual(stub.strafe_calls[0]["time_out"], 10.0)  # 踱步最多 10 秒
-        self.assertEqual(stub.strafe_calls[0]["keys"], ("w", "a", "s", "d"))
+        self.assertEqual(stub.strafe_calls[0]["keys"], ("s", "w", "a", "d"))  # 后退优先
         self.assertEqual(stub.ctrl_calls, ["ctrl", "ctrl"])  # 切步行 + 恢复奔跑
         self.assertTrue(any("踱步" in msg for msg in stub.log_lines))
 
@@ -93,7 +93,7 @@ class TestFindZipLineBoardButton(unittest.TestCase):
             stub, direct_wait=0.02, total_time_out=60.0)
         self.assertIs(result, box)
         self.assertEqual(len(stub.strafe_calls), 2)  # 踱步 + 前后移动各一次
-        self.assertEqual(stub.strafe_calls[1]["keys"], ("w", "s"))  # 阶段三仅前后移动
+        self.assertEqual(stub.strafe_calls[1]["keys"], ("s", "w"))  # 阶段三仅前后移动,后退优先
         # 阶段三时限为剩余时间：不超过总超时，且确实用掉了大部分预算
         self.assertLessEqual(stub.strafe_calls[1]["time_out"], 60.0)
         self.assertGreater(stub.strafe_calls[1]["time_out"], 55.0)


### PR DESCRIPTION
## 背景

传送落地后，右下角「登上滑索架」交互按钮可能因附近设备遮挡或加载延迟而不出现，原先仅原地 OCR 等待，超时即失败。滑索换乘场景下同样需要再次寻找该按钮。

## 改动

`DeliveryTask._find_zip_line_board_button` 改为三阶段搜索：

1. **阶段一**：`ensure_main()` 确认主界面后直接原地查找约 5 秒；
2. **阶段二**：未找到则 `ctrl` 切换步行模式，小幅度踱步搜索，最多持续 **10 秒**；
3. **阶段三**：仍找不到则改为仅 **W/S 前后移动**继续搜索，直到总超时（调用处传 120s，沿用 #224 延长后的等待预算）。

要点：

- **后退优先**：踱步键序为 `S → W → A → D`，前后移动为 `S → W`——换乘落点常越过滑索架，后退最容易重新看到按钮；
- **全程步行不奔跑**：进入移动搜索前 `ctrl` 切步行，搜索结束（无论成败）恢复奔跑模式，与 `navigation_mixin` 结束时的处理一致；
- **统一总截止时间**：三个阶段共用 `deadline = start + max(0, total_time_out)`，阶段一也被截断，任何阶段的时限都不超过实际剩余时间。

## 测试

- `tests/TestFindZipLineBoardButton.py` 5 个单测：
  - 阶段一直接命中不踱步、不切换步行；
  - 踱步命中且时限不超过 10 秒、ctrl 恰好切换/恢复各一次；
  - 踱步超时后进入 W/S 阶段并命中；
  - 总预算耗尽返回 None 且不进入后续阶段；
  - 阶段一耗尽正数短预算时立即返回（不切步行、时钟不超过截止时间+一个步长）。
- 全量测试通过。

基于 master cherry-pick，已解决与 #224 在同一段落上的冲突（保留 120s 预算意图）。