### PR TITLE
feat: 合成指纹铸造dId设为最高优先级(纯Python,无次数上限)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
     "pynput==1.8.2",
     "imagehash==4.3.2",
     "pyautogui==0.9.54",
+    "cryptography>=44.0.0",
     "scikit-image==0.26.0",
 ]
 

--- a/src/core/map_device_fingerprint.py
+++ b/src/core/map_device_fingerprint.py
@@ -1,0 +1,231 @@
+# -*- coding: utf-8 -*-
+# ruff: noqa: UP009
+"""合成数美(SMSdk)设备指纹并注册，纯 Python 铸造地图 dId。
+
+算法移植自 NoelZong/skland-auto-sign 的 SecuritySm 实现（经本地
+auto-checkin 工具实测可用，与本项目同 organization/公钥/端点）。
+独立成文件的原因：字段映射表与指纹模板可能随数美前端版本变化，
+后续调整只改这里，不影响 ``map_device_id`` 的调用方。
+
+流程（与官方 SDK 等价）：
+1. 构造伪浏览器环境档案（UA/canvas 指纹/分辨率/时区等固定模板）；
+2. 已知字段按 :data:`_DES_RULE` 逐项 3DES-ECB 加密并改名为两字母键；
+3. 整体 gzip+b64 后用 AES-128-CBC 加密
+   （key=md5(uid)[:16]，iv=``0102030405060708``，ZeroPadding）；
+4. uid 用官方 RSA 公钥加密作为 ep 信封；
+5. POST ``https://fp-it.portal101.cn/deviceprofile/v4``，
+   返回 code=1100 表示签发成功，取 ``B + detail.deviceId``。
+
+每次铸造的 uid/smid/vpw 均随机生成，无注册载荷次数上限。
+"""
+import base64
+import gzip
+import hashlib
+import json
+import time
+import urllib.request
+import uuid
+import warnings
+
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import padding as rsa_padding
+from cryptography.hazmat.primitives.ciphers.algorithms import AES
+
+try:  # cryptography 48+ 将 TripleDES 移入 decrepit
+    from cryptography.hazmat.decrepit.ciphers.algorithms import TripleDES
+except ImportError:  # pragma: no cover - 兼容旧版本
+    from cryptography.hazmat.primitives.ciphers.algorithms import TripleDES
+from cryptography.hazmat.primitives.ciphers.base import Cipher
+from cryptography.hazmat.primitives.ciphers.modes import CBC, ECB
+
+DEVICEPROFILE_URL = "https://fp-it.portal101.cn/deviceprofile/v4"
+MAP_PAGE_URL = "https://game.skland.com/map/endfield"
+
+_SM_CONFIG = {
+    "organization": "UWXspnCCJN4sfYlNfqps",
+    "appId": "default",
+    # 官方地图页 _smConf 内嵌的 RSA 公钥（公开静态资源）
+    "publicKey": (
+        "MIGfMA0GCSqGSIb3DQEBAQUAA4GNADCBiQKBgQCmxMNr7n8ZeT0tE1R9j/mPixoinPkeM+k4VGIn"
+        "/s0k7N5rJAfnZ0eMER+QhwFvshzo0LNmeUkpR8uIlU/GEVr8mN28sKmwd2gpygqj0ePnBmOW4v0Z"
+        "VwbSYK+izkhVFk2V/doLoMbWy6b+UnA8mkjvg0iYWRByfRsK2gdl7llqCwIDAQAB"
+    ),
+}
+
+_PK = serialization.load_der_public_key(base64.b64decode(_SM_CONFIG["publicKey"]))
+
+# 已知字段的 3DES 加密键与改名映射（逆向自官方 SDK）
+_DES_RULE = {
+    "appId": {"key": "uy7mzc4h", "name": "xx"},
+    "canvas": {"key": "snrn887t", "name": "yk"},
+    "clientSize": {"key": "cpmjjgsu", "name": "zx"},
+    "organization": {"key": "78moqjfc", "name": "dp"},
+    "os": {"key": "je6vk6t4", "name": "pj"},
+    "platform": {"key": "pakxhcd2", "name": "gm"},
+    "plugins": {"key": "v51m3pzl", "name": "kq"},
+    "pmf": {"key": "2mdeslu3", "name": "vw"},
+    "referer": {"key": "y7bmrjlc", "name": "ab"},
+    "res": {"key": "whxqm2a7", "name": "hf"},
+    "rtype": {"key": "x8o2h2bl", "name": "lo"},
+    "sdkver": {"key": "9q3dcxp2", "name": "sc"},
+    "status": {"key": "2jbrxxw4", "name": "an"},
+    "subVersion": {"key": "eo3i2puh", "name": "ns"},
+    "svm": {"key": "fzj3kaeh", "name": "qr"},
+    "time": {"key": "q2t3odsk", "name": "nb"},
+    "timezone": {"key": "1uv05lj5", "name": "as"},
+    "tn": {"key": "x9nzj1bp", "name": "py"},
+    "trees": {"key": "acfs0xo4", "name": "pi"},
+    "ua": {"key": "k92crp1t", "name": "bj"},
+    "url": {"key": "y95hjkoo", "name": "cf"},
+    "vpw": {"key": "r9924ab5", "name": "ca"},
+}
+# 只改名不加密的字段
+_DES_RENAME = {"box": "jf"}
+
+# 固定的伪浏览器环境模板（大量实现共用该模板；被批量风控时调整这里）
+_BROWSER_ENV = {
+    "plugins": (
+        "MicrosoftEdgePDFPluginPortableDocumentFormatinternal-pdf-viewer1,"
+        "MicrosoftEdgePDFViewermhjfbmdgcfjbbpaeojofohoefgiehjai1"
+    ),
+    "ua": (
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+        "(KHTML, like Gecko) Chrome/129.0.0.0 Safari/537.36 Edg/129.0.0.0"
+    ),
+    "canvas": "259ffe69",
+    "timezone": -480,
+    "platform": "Win32",
+    "url": "https://www.skland.com/",
+    "referer": "",
+    "res": "1920_1080_24_1.25",
+    "clientSize": "0_0_1080_1920_1920_1080_1920_1080",
+    "status": "0011",
+}
+
+
+def _des(o: dict) -> dict:
+    """按规则表逐项 3DES-ECB 加密并改名；不在表内的字段原样保留。"""
+    result: dict = {}
+    for key, value in o.items():
+        rule = _DES_RULE.get(key)
+        if rule:
+            # 单键 8 字节 3DES 是官方 SDK 的既有行为，忽略 cryptography 弃用告警
+            with warnings.catch_warnings():
+                warnings.simplefilter("ignore")
+                cipher = Cipher(TripleDES(rule["key"].encode("utf-8")), ECB())
+            data = str(value).encode("utf-8") + b"\x00" * 8
+            result[rule["name"]] = base64.b64encode(
+                cipher.encryptor().update(data)
+            ).decode("utf-8")
+        elif key in _DES_RENAME:
+            result[_DES_RENAME[key]] = value
+        else:
+            result[key] = value
+    return result
+
+
+def _aes(v: bytes, k: bytes) -> str:
+    """AES-128-CBC(ZeroPadding, iv=0102030405060708)，输出 hex。"""
+    cipher = Cipher(AES(k), CBC(b"0102030405060708"))
+    v += b"\x00"
+    while len(v) % 16 != 0:
+        v += b"\x00"
+    return cipher.encryptor().update(v).hex()
+
+
+def _gzip_b64(o: dict) -> bytes:
+    stream = gzip.compress(json.dumps(o, ensure_ascii=False).encode("utf-8"), 2, mtime=0)
+    return base64.b64encode(stream)
+
+
+def _get_tn(o: dict) -> str:
+    """完整性校验串：按键排序拼接所有值（数值乘 10000，dict 递归）。"""
+    parts: list[str] = []
+    for key in sorted(o.keys()):
+        value = o[key]
+        if isinstance(value, (int, float)):
+            value = str(value * 10000)
+        elif isinstance(value, dict):
+            value = _get_tn(value)
+        parts.append(value)
+    return "".join(parts)
+
+
+def _get_smid() -> str:
+    """生成长度合规的 smid：时间戳 + 随机 md5 + 校验尾。"""
+    t = time.localtime()
+    stamp = f"{t.tm_year:04d}{t.tm_mon:02d}{t.tm_mday:02d}{t.tm_hour:02d}{t.tm_min:02d}{t.tm_sec:02d}"
+    v = stamp + hashlib.md5(str(uuid.uuid4()).encode()).hexdigest() + "00"
+    tail = hashlib.md5(("smsk_web_" + v).encode()).hexdigest()[:14]
+    return v + tail + "0"
+
+
+def build_registration_payload() -> tuple[dict, bytes]:
+    """构造一份全新注册载荷。
+
+    Returns:
+        ``(payload_json_dict, uid_bytes)``：uid 是被 RSA 信封加密的原始值，
+        仅用于测试断言与调试，正常铸造流程不需要保存。
+    """
+    uid = str(uuid.uuid4()).encode("utf-8")
+    pri_id = hashlib.md5(uid).hexdigest()[:16].encode("utf-8")
+    ep = base64.b64encode(_PK.encrypt(uid, rsa_padding.PKCS1v15())).decode("utf-8")
+
+    now_ms = int(time.time() * 1000)
+    profile = {
+        **_BROWSER_ENV,
+        "vpw": str(uuid.uuid4()),
+        "svm": now_ms,
+        "trees": str(uuid.uuid4()),
+        "pmf": now_ms,
+        "protocol": 102,
+        "organization": _SM_CONFIG["organization"],
+        "appId": _SM_CONFIG["appId"],
+        "os": "web",
+        "version": "3.0.0",
+        "sdkver": "3.0.0",
+        "box": "",
+        "rtype": "all",
+        "smid": _get_smid(),
+        "subVersion": "1.0.0",
+        "time": 0,
+    }
+    profile["tn"] = hashlib.md5(_get_tn(profile).encode()).hexdigest()
+
+    payload = {
+        "appId": "default",
+        "compress": 2,
+        "data": _aes(_gzip_b64(_des(profile)), pri_id),
+        "encode": 5,
+        "ep": ep,
+        "organization": _SM_CONFIG["organization"],
+        "os": "web",
+    }
+    return payload, uid
+
+
+def mint_device_id_synthetic(timeout: float = 15.0) -> str:
+    """合成设备指纹并向数美注册，返回形如 ``B<deviceId>`` 的 dId。
+
+    失败（网络异常/非 1100 响应/未签发）抛出异常，由调用方回退到下一条路径。
+    """
+    payload, _uid = build_registration_payload()
+    req = urllib.request.Request(
+        DEVICEPROFILE_URL,
+        data=json.dumps(payload).encode("utf-8"),
+        method="POST",
+        headers={
+            "Content-Type": "application/json;charset=UTF-8",
+            "User-Agent": "Mozilla/5.0 ok-ef map websocket client",
+            "Origin": MAP_PAGE_URL.rsplit("/", 2)[0],
+            "Referer": MAP_PAGE_URL,
+        },
+    )
+    with urllib.request.urlopen(req, timeout=timeout) as resp:
+        result = json.loads(resp.read().decode("utf-8"))
+    if result.get("code") != 1100:
+        raise RuntimeError(f"数美合成指纹注册失败: {result}")
+    device_id = str((result.get("detail") or {}).get("deviceId") or "").strip()
+    if len(device_id) < 16:
+        raise RuntimeError(f"数美合成指纹未签发有效 deviceId: {result}")
+    return "B" + device_id

--- a/src/core/map_device_fingerprint.py
+++ b/src/core/map_device_fingerprint.py
@@ -55,6 +55,9 @@ _SM_CONFIG = {
 _PK = serialization.load_der_public_key(base64.b64decode(_SM_CONFIG["publicKey"]))
 
 # 已知字段的 3DES 加密键与改名映射，逆向自官方 SDK。
+# 注意：这些 8 字节键是公开的协议常量（与上游开源实现
+# NoelZong/skland-auto-sign 等完全一致），仅用于指纹报文的混淆格式，
+# 不用于保护任何数据，因此不属于"密钥/凭据"类敏感信息。
 # 注意：这些键值不是敏感凭据，而是数美 SDK 公开前端脚本中的固定
 # 协议常量，与下方 RSA 公钥同性质，任何人均可从公开静态资源反编译
 # 得到；仅用于构造合法报文格式，不提供任何保密性，故随源码提交。

--- a/src/core/map_device_fingerprint.py
+++ b/src/core/map_device_fingerprint.py
@@ -54,7 +54,10 @@ _SM_CONFIG = {
 
 _PK = serialization.load_der_public_key(base64.b64decode(_SM_CONFIG["publicKey"]))
 
-# 已知字段的 3DES 加密键与改名映射（逆向自官方 SDK）
+# 已知字段的 3DES 加密键与改名映射（逆向自官方 SDK）。
+# 注意：这些键值不是敏感凭据，而是数美 SDK 公开前端脚本中的固定
+# 协议常量（与下方 RSA 公钥同性质，任何人均可从公开静态资源反编译
+# 得到），仅用于构造合法报文格式，不提供任何保密性；故随源码提交。
 _DES_RULE = {
     "appId": {"key": "uy7mzc4h", "name": "xx"},
     "canvas": {"key": "snrn887t", "name": "yk"},

--- a/src/core/map_device_fingerprint.py
+++ b/src/core/map_device_fingerprint.py
@@ -54,10 +54,10 @@ _SM_CONFIG = {
 
 _PK = serialization.load_der_public_key(base64.b64decode(_SM_CONFIG["publicKey"]))
 
-# 已知字段的 3DES 加密键与改名映射（逆向自官方 SDK）。
+# 已知字段的 3DES 加密键与改名映射，逆向自官方 SDK。
 # 注意：这些键值不是敏感凭据，而是数美 SDK 公开前端脚本中的固定
-# 协议常量（与下方 RSA 公钥同性质，任何人均可从公开静态资源反编译
-# 得到），仅用于构造合法报文格式，不提供任何保密性；故随源码提交。
+# 协议常量，与下方 RSA 公钥同性质，任何人均可从公开静态资源反编译
+# 得到；仅用于构造合法报文格式，不提供任何保密性，故随源码提交。
 _DES_RULE = {
     "appId": {"key": "uy7mzc4h", "name": "xx"},
     "canvas": {"key": "snrn887t", "name": "yk"},

--- a/src/core/map_device_fingerprint.py
+++ b/src/core/map_device_fingerprint.py
@@ -171,7 +171,8 @@ def build_registration_payload() -> tuple[dict, bytes]:
         仅用于测试断言与调试，正常铸造流程不需要保存。
     """
     uid = str(uuid.uuid4()).encode("utf-8")
-    pri_id = hashlib.md5(uid).hexdigest()[:16].encode("utf-8")  # NOSONAR (python:S4790) 数美协议规定的密钥派生方式，非安全哈希用途
+    # md5 派生 AES 密钥是数美协议的规定算法，非安全哈希用途
+    pri_id = hashlib.md5(uid).hexdigest()[:16].encode("utf-8")  # NOSONAR
     ep = base64.b64encode(_PK.encrypt(uid, rsa_padding.PKCS1v15())).decode("utf-8")
 
     now_ms = int(time.time() * 1000)
@@ -193,8 +194,8 @@ def build_registration_payload() -> tuple[dict, bytes]:
         "subVersion": "1.0.0",
         "time": 0,
     }
-    # NOSONAR (python:S4790) tn 是数美协议要求的完整性校验串，算法固定为 MD5，非安全用途
-    profile["tn"] = hashlib.md5(_get_tn(profile).encode()).hexdigest()
+    # tn 是数美协议要求的完整性校验串，算法固定为 MD5，非安全用途
+    profile["tn"] = hashlib.md5(_get_tn(profile).encode()).hexdigest()  # NOSONAR
 
     payload = {
         "appId": "default",

--- a/src/core/map_device_fingerprint.py
+++ b/src/core/map_device_fingerprint.py
@@ -171,7 +171,7 @@ def build_registration_payload() -> tuple[dict, bytes]:
         仅用于测试断言与调试，正常铸造流程不需要保存。
     """
     uid = str(uuid.uuid4()).encode("utf-8")
-    pri_id = hashlib.md5(uid).hexdigest()[:16].encode("utf-8")
+    pri_id = hashlib.md5(uid).hexdigest()[:16].encode("utf-8")  # NOSONAR (python:S4790) 数美协议规定的密钥派生方式，非安全哈希用途
     ep = base64.b64encode(_PK.encrypt(uid, rsa_padding.PKCS1v15())).decode("utf-8")
 
     now_ms = int(time.time() * 1000)
@@ -193,6 +193,7 @@ def build_registration_payload() -> tuple[dict, bytes]:
         "subVersion": "1.0.0",
         "time": 0,
     }
+    # NOSONAR (python:S4790) tn 是数美协议要求的完整性校验串，算法固定为 MD5，非安全用途
     profile["tn"] = hashlib.md5(_get_tn(profile).encode()).hexdigest()
 
     payload = {

--- a/src/core/map_device_fingerprint.py
+++ b/src/core/map_device_fingerprint.py
@@ -158,8 +158,9 @@ def _get_smid() -> str:
     """生成长度合规的 smid：时间戳 + 随机 md5 + 校验尾。"""
     t = time.localtime()
     stamp = f"{t.tm_year:04d}{t.tm_mon:02d}{t.tm_mday:02d}{t.tm_hour:02d}{t.tm_min:02d}{t.tm_sec:02d}"
-    v = stamp + hashlib.md5(str(uuid.uuid4()).encode()).hexdigest() + "00"
-    tail = hashlib.md5(("smsk_web_" + v).encode()).hexdigest()[:14]
+    # md5 在此仅用于生成随机标识与校验尾，非安全哈希用途，协议规定算法
+    v = stamp + hashlib.md5(str(uuid.uuid4()).encode()).hexdigest() + "00"  # NOSONAR
+    tail = hashlib.md5(("smsk_web_" + v).encode()).hexdigest()[:14]  # NOSONAR
     return v + tail + "0"
 
 

--- a/src/core/map_device_id.py
+++ b/src/core/map_device_id.py
@@ -23,6 +23,8 @@
 
 因此本模块采用混合策略（按优先级）：
 - 已持久化的 dId 直接复用（与账号无关，可长期使用）；
+- 「合成指纹」纯 Python 本地构造注册档案直接铸造（无次数上限，
+  算法见 ``map_device_fingerprint.py``，可能随数美版本变化）；
 - 「本地保存的注册载荷」走纯 HTTP 重放铸造（无需浏览器/Node）；
 - 「Node 运行官方 SMSdk 本体」（``smsdk_runner.mjs`` + 官方 SDK 脚本，
   用浏览器环境垫片让 SDK 自己生成并提交注册请求），无需浏览器、
@@ -489,9 +491,22 @@ def mint_device_id_browser(timeout: float = _MINT_TIMEOUT_SECONDS) -> str:
 
 
 def mint_device_id() -> str:
-    """铸造全新 dId：HTTP 重放 -> Node 运行官方 SDK -> 临时浏览器。"""
+    """铸造全新 dId：合成指纹 -> HTTP 重放 -> Node 运行官方 SDK -> 临时浏览器。
+
+    合成指纹（``map_device_fingerprint``）为纯 Python 本地构造注册档案，
+    无载荷次数上限、无 Node/浏览器依赖，是首选路径；算法可能随数美
+    前端版本变化，已独立成单独文件便于后续调整。任一路径失败自动
+    回退到下一条。
+    """
+    def _mint_synthetic() -> str:
+        # 延迟导入：cryptography 缺失时仅该路径不可用，不影响其余路径
+        from src.core.map_device_fingerprint import mint_device_id_synthetic
+
+        return mint_device_id_synthetic()
+
     errors: list[str] = []
     for label, mint in (
+        ("合成指纹", _mint_synthetic),
         ("HTTP 重放", mint_device_id_http),
         ("Node+官方SDK", mint_device_id_node),
         ("临时浏览器", mint_device_id_browser),

--- a/tests/TestMapDeviceFingerprint.py
+++ b/tests/TestMapDeviceFingerprint.py
@@ -1,0 +1,80 @@
+# -*- coding: utf-8 -*-
+# ruff: noqa: UP009, N999
+"""验证合成数美指纹模块：载荷结构、字段改名加密、失败路径。"""
+import base64
+import json
+import unittest
+from io import BytesIO
+from unittest import mock
+
+from src.core import map_device_fingerprint as fp
+
+
+class TestMapDeviceFingerprint(unittest.TestCase):
+    def test_des_renames_and_passthrough(self):
+        """规则表内字段改名为两字母键；box 改名不加密；未知键原样保留。"""
+        result = fp._des({"appId": "default", "box": "", "protocol": 102})
+        self.assertIn("xx", result)  # appId -> xx
+        self.assertNotIn("appId", result)
+        self.assertEqual(result["jf"], "")  # box -> jf（不改值）
+        self.assertEqual(result["protocol"], 102)  # 不在表中，原样保留
+
+    def test_des_deterministic(self):
+        """同输入两次加密结果一致（ECB 确定性）。"""
+        a = fp._des({"platform": "Win32"})
+        b = fp._des({"platform": "Win32"})
+        self.assertEqual(a["gm"], b["gm"])
+
+    def test_build_registration_payload_structure(self):
+        """注册载荷包含必需键，ep 为合法 base64，data 为 hex 密文。"""
+        payload, uid = fp.build_registration_payload()
+        for key in ("appId", "compress", "data", "encode", "ep", "organization", "os"):
+            self.assertIn(key, payload)
+        self.assertEqual(payload["compress"], 2)
+        self.assertEqual(payload["encode"], 5)
+        self.assertEqual(payload["organization"], fp._SM_CONFIG["organization"])
+        base64.b64decode(payload["ep"])  # ep 可解码
+        self.assertTrue(len(uid) > 0)
+
+    def test_mint_rejects_non_1100(self):
+        """服务端返回非 1100 时抛出 RuntimeError。"""
+
+        class _FakeResp:
+            def read(self):
+                return json.dumps({"code": 1902, "detail": {}}).encode("utf-8")
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        with mock.patch.object(fp.urllib.request, "urlopen", return_value=_FakeResp()):
+            with self.assertRaises(RuntimeError) as ctx:
+                fp.mint_device_id_synthetic()
+            self.assertIn("1902", str(ctx.exception))
+
+    def test_mint_returns_prefixed_device_id(self):
+        """code=1100 时返回 B 前缀的 deviceId。"""
+
+        class _FakeResp:
+            def read(self):
+                stream = BytesIO(json.dumps({
+                    "code": 1100,
+                    "detail": {"deviceId": "x" * 32},
+                }).encode("utf-8"))
+                return stream.read()
+
+            def __enter__(self):
+                return self
+
+            def __exit__(self, *args):
+                return False
+
+        with mock.patch.object(fp.urllib.request, "urlopen", return_value=_FakeResp()):
+            did = fp.mint_device_id_synthetic()
+        self.assertEqual(did, "B" + "x" * 32)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/TestMapDeviceFingerprint.py
+++ b/tests/TestMapDeviceFingerprint.py
@@ -34,7 +34,7 @@ class TestMapDeviceFingerprint(unittest.TestCase):
         self.assertEqual(payload["encode"], 5)
         self.assertEqual(payload["organization"], fp._SM_CONFIG["organization"])
         base64.b64decode(payload["ep"])  # ep 可解码
-        self.assertTrue(len(uid) > 0)
+        self.assertGreater(len(uid), 0)
 
     def test_mint_rejects_non_1100(self):
         """服务端返回非 1100 时抛出 RuntimeError。"""

--- a/uv.lock
+++ b/uv.lock
@@ -12,6 +12,29 @@ wheels = [
 ]
 
 [[package]]
+name = "cffi"
+version = "2.1.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pycparser", marker = "implementation_name != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9e/ef/008a1939e372c06329a3fce4279c02f328488f3526744906eeec3da7ad5f/cffi-2.1.1.tar.gz", hash = "sha256:dd31f52ea1086513bb9df30f8fcee9b8918323ae067a3d5b78bc826a000712be", size = 530807, upload-time = "2026-08-03T21:21:18.939Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/10/69/43965eccfdead3b9220015fd1320e117be8c6ed01a62ffab76eeb752f5d5/cffi-2.1.1-cp312-cp312-macosx_10_15_x86_64.whl", hash = "sha256:c8c69575568085ba0b1b10c0249d779a214aea6f6522e949a0fc9fb0fcb449d0", size = 184821, upload-time = "2026-08-03T21:19:44.887Z" },
+    { url = "https://files.pythonhosted.org/packages/54/7d/16e5a096677b5e313ca80cd5e5170efa3ea44624a82bb111925522da64b1/cffi-2.1.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:f81b3b8f3d4e343550fa4baa0e479bba9f2d29ce9c2e9b51d1ce1718d7442fcf", size = 184719, upload-time = "2026-08-03T21:19:46.129Z" },
+    { url = "https://files.pythonhosted.org/packages/56/e6/8941622732edec876dd17d0453dce07317ae96db34f2ec1436c9d3785986/cffi-2.1.1-cp312-cp312-manylinux1_i686.manylinux2014_i686.manylinux_2_17_i686.manylinux_2_5_i686.whl", hash = "sha256:811bd1e21d32de12efca32393a0ab3f5133b54fce9bd44b8bd77ab07da14bf6a", size = 214799, upload-time = "2026-08-03T21:19:47.218Z" },
+    { url = "https://files.pythonhosted.org/packages/44/de/f98430906df1545ffde0d543dd124a7a439bc2cd32b36b9c53f805df7333/cffi-2.1.1-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:68e62fe11f30d5ca8289242866f0a5291402d8529ca2178ab8afc5c9694ae890", size = 222389, upload-time = "2026-08-03T21:19:48.331Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/5b/717f1526b9957b34456313c31645c5b82b8fb5c3fe9e4752999be7128bfc/cffi-2.1.1-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:4a7c934f7360e8cd64fe9efadcbd10c7c6364f531e432b9a4bf5ccbc9e0e8b50", size = 210249, upload-time = "2026-08-03T21:19:49.543Z" },
+    { url = "https://files.pythonhosted.org/packages/64/b3/f8aa4f3e34986c7e4ec45072d1b1b9dd295b6b18007b45518d79726dd725/cffi-2.1.1-cp312-cp312-manylinux2014_s390x.manylinux_2_17_s390x.whl", hash = "sha256:3143d81e29e1e20a9ce10901ec369012947876596f75a222235965f2b7ae832e", size = 208775, upload-time = "2026-08-03T21:19:50.918Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/db/dceb9dd5b231e1da801793f8acc9f3c52a7e1afe40bb1aae37e02b0faad5/cffi-2.1.1-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:c1453022f490d2459a11819d83ad1d586e9ff65a12ac3e705ffebd46d3685dcf", size = 221822, upload-time = "2026-08-03T21:19:52.054Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/d2/6cd24ae3be000a634109c247d1475d62e5616d0dc78c82770942ec384248/cffi-2.1.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:208f941bb9d18e768138677f0a6d2ce01f590df56043dda1df1535ac57c88517", size = 225232, upload-time = "2026-08-03T21:19:53.109Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/52/3fa190537004dd7f0ab860a6dc7c0175b8667f68d1e618a46f5498d30250/cffi-2.1.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:210019b6c7cf07f081b4c54635c8cf744377001350e29cc0f81c4377b4797735", size = 223597, upload-time = "2026-08-03T21:19:54.515Z" },
+    { url = "https://files.pythonhosted.org/packages/80/fb/0bb75b7039588c074b37ae99f40d9bfddf990ecb2fbc346ebccd2e56b9be/cffi-2.1.1-cp312-cp312-win32.whl", hash = "sha256:046bfc24911b37851ee1b51aab8bffe713d89c68c6a057b09484ce9fd5f69b4e", size = 175292, upload-time = "2026-08-03T21:19:55.566Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/79/615cc094e2fb508cade7de88d3b4f6c4ec2bab695c97bce9153dc65aadf5/cffi-2.1.1-cp312-cp312-win_amd64.whl", hash = "sha256:f53e442b08449d42821fa4a4fba000095af9f62742a500f978a9f557ec44339a", size = 185919, upload-time = "2026-08-03T21:19:56.89Z" },
+    { url = "https://files.pythonhosted.org/packages/70/c6/d0ea84713fe46b243a436a18fcd47d639732747e21635c8a27191b06dc30/cffi-2.1.1-cp312-cp312-win_arm64.whl", hash = "sha256:7bde5e4cc5c10140859842b9d383af292b22639a4dffb725314baf45968cef80", size = 180093, upload-time = "2026-08-03T21:19:58.155Z" },
+]
+
+[[package]]
 name = "charset-normalizer"
 version = "3.4.9"
 source = { registry = "https://pypi.org/simple" }
@@ -40,6 +63,43 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/c6/2a/65274c13327f637ec13af8d39f2cf579d9ebe7a0e683696b5f05236d2805/comtypes-1.4.16.tar.gz", hash = "sha256:cd66d1add01265cface4df51ba1e31cd1657e04463c281c802e737e79e1ba93c", size = 260252, upload-time = "2026-03-02T23:11:42.413Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/5f/7c/0eb685107290b6221c03c46d39214a4e42a124189691cb83ae3228257f46/comtypes-1.4.16-py3-none-any.whl", hash = "sha256:e18d85179ff12955524c5a8c3bc09cb3c0d890f1da4d7123d14244c7b78f84c8", size = 296230, upload-time = "2026-03-02T23:11:41.049Z" },
+]
+
+[[package]]
+name = "cryptography"
+version = "50.0.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cffi", marker = "platform_python_implementation != 'PyPy'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/de/41/6cbdcf9142d00fe82836fbb51e503e58088575cf7a0fe1dbff6695bf0840/cryptography-50.0.0.tar.gz", hash = "sha256:eeac2acb5a20ed25e0ad6d1df9891a520b78b404266b6d11778f25d5d691a6c9", size = 880201, upload-time = "2026-07-31T14:25:10.11Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c5/5c/59086b4aac5e879d38ddbcf74e4be7ade89cebc3eb199a55da998c3bb46a/cryptography-50.0.0-cp311-abi3-macosx_11_0_arm64.whl", hash = "sha256:031e2d5dd4bb9caa3ca9c82e5a197fd8ae680232cee62603d1a813f3f07e3d03", size = 4001252, upload-time = "2026-07-31T14:23:33.331Z" },
+    { url = "https://files.pythonhosted.org/packages/57/ef/8f2df13c7216bcad3e1c74e07f6e193d93e998e114f524a53877c9af27ad/cryptography-50.0.0-cp311-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:fd9192b7b70c573d7f214eb1ae35e00d359f6f5e4b27c7e21e30de1fc6204645", size = 4719554, upload-time = "2026-07-31T14:23:35.611Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/41/029086c34d91052fc3b88bcc8056f709a7c915c7a23b235a54eb800b1c97/cryptography-50.0.0-cp311-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:06a32a980526a6ab9a4b9bf8f7385800791e2bb960903cb6b530e4817509a3b7", size = 4702130, upload-time = "2026-07-31T14:23:37.635Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/ff/b6ce0954962e7f7b969f850a883744197bb3910bdfd7b6da162eab7d9f68/cryptography-50.0.0-cp311-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a1b30560f2acc95aa8b2e06e716a13dbfc97314747b80d9707e307f77b40d6b3", size = 4725244, upload-time = "2026-07-31T14:23:39.471Z" },
+    { url = "https://files.pythonhosted.org/packages/06/1e/63a1027cb7fec360a182208e1b7767d5aa1fe57be3d6aa856e69a321edc0/cryptography-50.0.0-cp311-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:8d89f3976b10b4ce31118de72329025f70d2c6ead14a8217c5514dd2c6d5a78f", size = 5342265, upload-time = "2026-07-31T14:23:41.286Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/72/a1116d683a6d7ece94590013882515de087edf9ef0e6292aae615a44df73/cryptography-50.0.0-cp311-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:b42a28c1844fd9de8f3f7d540e36b66f3a9c83fceac7170ebc7a6a19edd9dcae", size = 4734609, upload-time = "2026-07-31T14:23:43.139Z" },
+    { url = "https://files.pythonhosted.org/packages/15/37/36a9c479bbe49acea2636c7fd3360d20f7b7e079c300352011c44850b181/cryptography-50.0.0-cp311-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:900131fafd8aead39ac7dd3a7e833be754c17a95cfd91221636949fe4eb0aa8a", size = 4356517, upload-time = "2026-07-31T14:23:44.939Z" },
+    { url = "https://files.pythonhosted.org/packages/32/98/8a151d64367204cbc63ec65d37502f1d9c53cf4bfc6ec3c532614dbec60d/cryptography-50.0.0-cp311-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:07949c449a1abcf60d1ee6e88956d89404c7df3c8258f46589e912988e551987", size = 4724529, upload-time = "2026-07-31T14:23:46.93Z" },
+    { url = "https://files.pythonhosted.org/packages/22/f6/ec13b470172126464a86bf54d2294a46d29837fc51ba3e45d4047946fb5e/cryptography-50.0.0-cp311-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:f89831ef99dd7dd169ab06d63a831adb9e20a87aac6d380266bbda5823349169", size = 5299852, upload-time = "2026-07-31T14:23:48.851Z" },
+    { url = "https://files.pythonhosted.org/packages/da/3a/f05e32c99d440c9bb891ea0e36c9091891e36be5a9a87ab2ee6ea20729f6/cryptography-50.0.0-cp311-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:82148ec5bddac30b51a5b3c1945075f896fa022cb93f8e4a01e9f6ee95292c5f", size = 4734462, upload-time = "2026-07-31T14:23:50.861Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/dc/bd72b26be8953f80625f63151efd38eee71c76ca6cf591c08ff34615a79e/cryptography-50.0.0-cp311-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:1489e263a8048bb8b6a8bac662eb2d402ea5d2b7b4699b72f385f1e2772db105", size = 4852708, upload-time = "2026-07-31T14:23:52.715Z" },
+    { url = "https://files.pythonhosted.org/packages/27/20/c930314a2ab476d15dec966ec87e2e9637bb02b06106b12c0396c57bb603/cryptography-50.0.0-cp311-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:7cec5b856506da6defb290f30c9ee687d5f5e8cb0bd3f6459dde43b0b4fa40ef", size = 5004179, upload-time = "2026-07-31T14:23:54.887Z" },
+    { url = "https://files.pythonhosted.org/packages/32/2e/c9db68a0c4bfa28e310707527c0ee3a2bd254104d2e02e68f368e197aa4c/cryptography-50.0.0-cp311-abi3-win_amd64.whl", hash = "sha256:bd1c592e4d5974f0d08d4888e432157adba757c66da0246918e43677fafa2d30", size = 3840395, upload-time = "2026-07-31T14:23:56.677Z" },
+    { url = "https://files.pythonhosted.org/packages/03/37/73d005be173aff344af30e9fd2a576575cb2391a7101d9cd3842e1fa8cce/cryptography-50.0.0-cp39-abi3-macosx_11_0_arm64.whl", hash = "sha256:ccdc4a71a4dabae05de219404f9f4abc38e3b58422177ff93d0da05967dafa07", size = 4036009, upload-time = "2026-07-31T14:24:24.122Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/c6/7a6202a534e32103a285b7834a120869557fe198d51d7cfe59754c8bda9c/cryptography-50.0.0-cp39-abi3-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:910e1d2668e7de9648f2bcee30e180db2a6b15c30f887d7c4c93ddf96e3992e3", size = 4745252, upload-time = "2026-07-31T14:24:26.118Z" },
+    { url = "https://files.pythonhosted.org/packages/85/4f/0fa8c2f4428198f15d9ff8d63400e27afbf94ce833f6108da1eb3753f945/cryptography-50.0.0-cp39-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:a91296cb61e8df6f86d0c19cc4068228da256bf59bf86049fbd821084565327f", size = 4728939, upload-time = "2026-07-31T14:24:27.994Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/63/54dd723490ba2dc09b299682c10b38db38f159728bcaae8c591b8af2f22d/cryptography-50.0.0-cp39-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:e722f16708d854fe924790e051061f6704a472c3bac347b6fd88033ea8dd0dc5", size = 4748483, upload-time = "2026-07-31T14:24:30.254Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/dd/7c77d26285cc7f6991efce64a0f5b4f9383bfa5dd8c5033003eaf7db4cdb/cryptography-50.0.0-cp39-abi3-manylinux_2_28_ppc64le.whl", hash = "sha256:d764dcf130c428ef66786f866dd750f53182bc608813489915e9fc106bb0c82f", size = 5367599, upload-time = "2026-07-31T14:24:32.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/c9/f60aed34c013f317f92817b6c171c2d22a78270fa41109bd4b08af26b194/cryptography-50.0.0-cp39-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:105110f43a471dbd0060b9c9516cb8a6a79233631a04cc2ba16f28323ac6e025", size = 4762647, upload-time = "2026-07-31T14:24:34.599Z" },
+    { url = "https://files.pythonhosted.org/packages/be/f3/f9a0173b139372c3a48ed98154b45cc6b9de17c789d5ab552e621c293609/cryptography-50.0.0-cp39-abi3-manylinux_2_31_armv7l.whl", hash = "sha256:828743d939e9629bc267b8e2d08d8bb67cd4319c771a33d4b18b22dd8fb7440a", size = 4385197, upload-time = "2026-07-31T14:24:36.647Z" },
+    { url = "https://files.pythonhosted.org/packages/d8/36/83bb81f6e569bc38e1e4a7bc80f29b46bb9601920bc455fc8e888f5d5742/cryptography-50.0.0-cp39-abi3-manylinux_2_34_aarch64.whl", hash = "sha256:2a8183b489dc1f7f80f135780fadc1108f14b31b8a40411c7a5b17425f65f28b", size = 4748095, upload-time = "2026-07-31T14:24:39.493Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/16/d3008eff98c764979865834c3d386d4fd041b5f52e7f34fc29ac1a5eb515/cryptography-50.0.0-cp39-abi3-manylinux_2_34_ppc64le.whl", hash = "sha256:6e7d61120573a7f2cd94cc095f9e81f6967c61ccdf194285aa143ecec8e0b708", size = 5325948, upload-time = "2026-07-31T14:24:41.556Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/f8/d97f9603efda3888187bfdb893f26c41be4735c10631d05d284ee6b047c4/cryptography-50.0.0-cp39-abi3-manylinux_2_34_x86_64.whl", hash = "sha256:37fdb0d0111f1e2ff07139dfb79f1b49531f8e213c46f1163dd7642979b58c47", size = 4762400, upload-time = "2026-07-31T14:24:43.636Z" },
+    { url = "https://files.pythonhosted.org/packages/64/a2/4615c8f7d81a00b1d6e6afe19f694e1543582349fb5f4076f6cb5dc36485/cryptography-50.0.0-cp39-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:c87f62a3d3b9888ed0fdde100ec06aa61ca9cd44bad9057d1dff9a516b5f5bb9", size = 4878208, upload-time = "2026-07-31T14:24:45.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/1a/efcfb02f91407149a0dacffffab791f7e19bf6385f63b3666dc8b5e5c9c8/cryptography-50.0.0-cp39-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:65c2c3add92b45fd0709db8594536aea39c2a67af0e27ffcf049c498501140b7", size = 5037050, upload-time = "2026-07-31T14:24:47.697Z" },
+    { url = "https://files.pythonhosted.org/packages/57/30/4a22984d4f1bdfb8c054f07a92bc176b97a3134cc1d6c4b3bffb1f3688b4/cryptography-50.0.0-cp39-abi3-win_amd64.whl", hash = "sha256:d24fead1d4d076e1bfb006dcec392074a3cd8d7b4fc8a595aa64073b2b7a96ba", size = 3874135, upload-time = "2026-07-31T14:24:50.085Z" },
 ]
 
 [[package]]
@@ -166,6 +226,7 @@ name = "ok-end-field"
 version = "0.1.0"
 source = { virtual = "." }
 dependencies = [
+    { name = "cryptography" },
     { name = "imagehash" },
     { name = "json5" },
     { name = "ok-script" },
@@ -189,6 +250,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "cryptography", specifier = ">=44.0.0" },
     { name = "imagehash", specifier = "==4.3.2" },
     { name = "json5", specifier = "==0.15.0" },
     { name = "ok-script", specifier = "==2.0.2" },
@@ -393,6 +455,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d2/f7/4d61927a6be0ce33129b35221751c844e925619f199567517dbf10377ba1/pycocoa-25.12.4.tar.gz", hash = "sha256:6b174e972da63657ddf1095e6504e4cad63e143046752b71aa496e14e8f27722", size = 558218, upload-time = "2025-12-03T21:11:24.551Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/58/f6/0b1b50967c878eae9c84b68dc098ee004cabf57d0d7a449001ddf04b8aaf/pycocoa-25.12.4-py2.py3-none-any.whl", hash = "sha256:189f08be6f3b479bad53711776eec5687a9eddc30e88c1ac24ed458e6053ba1b", size = 227487, upload-time = "2025-12-03T21:11:26.182Z" },
+]
+
+[[package]]
+name = "pycparser"
+version = "3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/1b/7d/92392ff7815c21062bea51aa7b87d45576f649f16458d78b7cf94b9ab2e6/pycparser-3.0.tar.gz", hash = "sha256:600f49d217304a5902ac3c37e1281c9fe94e4d0489de643a9504c5cdfdfc6b29", size = 103492, upload-time = "2026-01-21T14:26:51.89Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/c3/44f3fbbfa403ea2a7c779186dc20772604442dde72947e7d01069cbe98e3/pycparser-3.0-py3-none-any.whl", hash = "sha256:b727414169a36b7d524c1c3e31839a521725078d7b2ff038656844266160a992", size = 48172, upload-time = "2026-01-21T14:26:50.693Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 背景

现有 dId 铸造链（载荷重放 → Node 跑官方 SDK → 临时浏览器）各有痛点：载荷有 6~8 次使用上限（耗尽后 1902）、Node 路径需下载校验 SDK、浏览器路径重。本地 `auto-checkin` 工具验证了**纯 Python 从零构造数美注册档案**的方案（移植自 NoelZong/skland-auto-sign 的 SecuritySm），实测可稳定签发。

## 改动

### 新增 `src/core/map_device_fingerprint.py`（算法独立成文件）

- 构造伪浏览器环境档案 → 已知字段按逆向规则表逐项 **3DES-ECB 加密改名** → gzip+b64 → AES-128-CBC(key=md5(uid)[:16], iv=0102030405060708) → RSA 信封 ep → `POST /deviceprofile/v4`
- 每次铸造 uid/smid/vpw 均随机，**无载荷次数上限**，无 Node/浏览器依赖
- 独立成文件的原因：字段映射与指纹模板可能随数美前端版本变化，后续调整只改这里

### `map_device_id.py` 接线

铸造优先级变为：**合成指纹 → 载荷重放 → Node → 浏览器兜底**；合成失败自动回退原有三级链，互不干扰。延迟导入保证 cryptography 缺失时仅该路径不可用。

### 依赖

- `pyproject.toml` 新增 `cryptography>=44.0.0`（安装约 10.8 MB，相对项目现有 PySide6/openvino 可忽略）

## 验证

- 本地实测：清空全部缓存后 `uv run python -m src.core.map_device_id --refresh` 直接经合成指纹路径铸出新 dId 并持久化
- 新增 5 个单测（载荷结构/字段改名加密确定性/非1100失败路径/B前缀返回），全量 307 tests OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增无需浏览器环境即可生成合成设备指纹并获取设备 ID 的能力。
  - 注册成功后返回统一格式的设备 ID。

- **优化**
  - 调整设备 ID 获取顺序，支持多级备用方案，适配更多运行环境。
  - 优化失败处理，异常时自动尝试其他方案。

- **测试**
  - 增加设备指纹生成、注册流程及异常处理的自动化测试。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->