### PR TITLE
fix: 重新生成 requirements.txt 同步 cryptography 依赖

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,10 +12,14 @@
 
 certifi==2026.7.22
     # via requests
+cffi==2.1.1
+    # via cryptography
 charset-normalizer==3.4.9
     # via requests
 comtypes==1.4.16
     # via pycaw
+cryptography==50.0.0
+    # via ok-end-field
 darkdetect==0.8.0
     # via pyside6-fluent-widgets
 idna==3.18
@@ -77,6 +81,8 @@ pycaw==20240210
     # via ok-script
 pyclipper==1.4.0
     # via onnxocr-ppocrv5
+pycparser==3.0
+    # via cffi
 pydirectinput==1.0.4
     # via ok-script
 pygetwindow==0.0.9


### PR DESCRIPTION
修复发布 Build CI 失败：`Verify requirements.txt reproducible` 校验不通过。

## 根因

PR #230（`bafaf8e`）在 `pyproject.toml` 加入 `cryptography>=44.0.0` 并更新了 `uv.lock`，但**未重新生成 `requirements.txt`**。导致发布 tag（如 `v1.0.61`）触发的 Build CI 在 `gen_release_requirements.py --check` 步骤失败。

## 变更

重新生成 `requirements.txt`，同步新增：

- `cryptography==50.0.0`（via ok-end-field）
- `cffi==2.1.1`（via cryptography）
- `pycparser==3.0`（via cffi）

## 验证

- `uv run --locked --no-sync python scripts/gen_release_requirements.py --check` → OK

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **依赖更新**
  * 新增加密功能相关依赖，提升应用对加密操作的支持。
  * 添加 CFFI 及其解析依赖，增强底层扩展兼容性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->