### PR TITLE
fix: 移除帝江号收菜放置线索确认框的偏移

### DIFF
--- a/src/tasks/daily/misc/daily_boat_mixin.py
+++ b/src/tasks/daily/misc/daily_boat_mixin.py
@@ -119,10 +119,9 @@ class DailyBoatMixin:
                 )
 
                 start_index = clue_index + 1
-        start_end_x_offset=0.3
         if self.wait_click_feature(
             feature=fL.skip_dialog_confirm,
-            box=self.box_of_screen(0.371+start_end_x_offset, 0.770, 0.397+start_end_x_offset, 0.811),
+            box=self.box_of_screen(0.371, 0.770, 0.397, 0.811),
             time_out=1,
             raise_if_not_found=False,
         ):


### PR DESCRIPTION
## 修复内容

帝江号收菜流程中，放置线索后的跳过确认框不再应用 0.3 的横向偏移，恢复原始坐标 (0.371, 0.770, 0.397, 0.811)。

## 背景

此前 `_give_clue` 中通过 `start_end_x_offset=0.3` 对跳过确认框做了横向偏移，导致确认框识别位置偏离实际按钮，可能造成点击失败。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修正每日任务中对话确认按钮的点击位置，提升交互准确性。
  * 移除不必要的点击区域偏移，避免确认操作点击失败。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->