### PR TITLE
fix: 地图dump脚本纳入saveMarks并过滤空名/名称strip

### DIFF
--- a/scripts/dump_endfield_map_marks.py
+++ b/scripts/dump_endfield_map_marks.py
@@ -292,29 +292,34 @@ def generate_simple_marks(out_dir: Path):
 
         data = data.get("data", {})
 
-        # templateId -> 名称
+        # templateId -> 名称（统一 strip，避免名称带换行/首尾空白）
         template_map = {
-            t["id"]: t["name"]
+            t["id"]: t["name"].strip()
             for t in data.get("markTemplates", [])
         }
 
-        # 收集所有物品名称
+        # 收集所有物品名称（跳过空名与排除项）
         for name in template_map.values():
-            if name not in EXCLUDE_MARKS:
+            if name and name not in EXCLUDE_MARKS:
                 all_names.add(name)
 
-        for mark in data.get("marks", []):
-            name = template_map.get(mark["templateId"])
+        def _add_point(map_id: str, name: str, pos: Any):
             if not name or name in EXCLUDE_MARKS:
-                continue
-
-            map_id = mark["mapId"]
-
+                return
+            if not isinstance(pos, dict):
+                return
             all_maps[map_id][name].append({
-                "x": mark["pos"]["x"],
-                "y": mark["pos"]["y"],
-                "z": mark["pos"]["z"],
+                "x": pos["x"],
+                "y": pos["y"],
+                "z": pos["z"],
             })
+
+        for mark in data.get("marks", []):
+            _add_point(mark["mapId"], template_map.get(mark["templateId"]), mark.get("pos"))
+
+        # saveMarks 中带坐标的标记（如中继器/供电桩）也纳入
+        for mark in data.get("saveMarks", []):
+            _add_point(mark.get("mapId"), template_map.get(mark.get("templateId")), mark.get("pos"))
 
     # 导出坐标
     export = {

--- a/scripts/dump_endfield_map_marks_public.py
+++ b/scripts/dump_endfield_map_marks_public.py
@@ -76,24 +76,28 @@ def main():
             data = data.get("data", {})
 
             template_map = {
-                item["id"]: item["name"]
+                item["id"]: item["name"].strip()
                 for item in data.get("markTemplates", [])
             }
 
-            all_names.update(template_map.values())
+            all_names.update(name for name in template_map.values() if name)
 
-            for mark in data.get("marks", []):
-                name = template_map.get(mark["templateId"])
+            def _add_point(mark: dict):
+                nonlocal duplicate_count
+                name = template_map.get(mark.get("templateId"))
                 if not name:
-                    continue
+                    return
+                pos = mark.get("pos")
+                if not isinstance(pos, dict):
+                    return
 
-                x = mark["pos"]["x"]
-                y = mark["pos"]["y"]
-                z = mark["pos"]["z"]
+                x = pos["x"]
+                y = pos["y"]
+                z = pos["z"]
 
                 coord = (x, y, z)
 
-                points = all_maps[mark["mapId"]][name]
+                points = all_maps[mark.get("mapId")][name]
 
                 if coord in points:
                     duplicate_count += 1
@@ -103,6 +107,13 @@ def main():
                     "y": y,
                     "z": z,
                 }
+
+            for mark in data.get("marks", []):
+                _add_point(mark)
+
+            # saveMarks 中带坐标的标记（如中继器/供电桩）也纳入
+            for mark in data.get("saveMarks", []):
+                _add_point(mark)
 
     summary = {
         map_id: {

--- a/scripts/dump_endfield_map_marks_public.py
+++ b/scripts/dump_endfield_map_marks_public.py
@@ -35,6 +35,12 @@ def write_json(path: Path, data):
     )
 
 
+EXCLUDE_MARKS = {
+    "长距滑索架",
+    "滑索架",
+}
+
+
 def main():
     print("Downloading map tree...")
 
@@ -80,12 +86,12 @@ def main():
                 for item in data.get("markTemplates", [])
             }
 
-            all_names.update(name for name in template_map.values() if name)
+            all_names.update(name for name in template_map.values() if name and name not in EXCLUDE_MARKS)
 
             def _add_point(mark: dict):
                 nonlocal duplicate_count
                 name = template_map.get(mark.get("templateId"))
-                if not name:
+                if not name or name in EXCLUDE_MARKS:
                     return
                 pos = mark.get("pos")
                 if not isinstance(pos, dict):


### PR DESCRIPTION
## 修复地图 dump 脚本

### 问题
- `item_names.json` 出现空字符串 `""` 条目（空模板名被误收），导致物品导航下拉框出现空选项
- 名称带换行/首尾空白（如 `协议纹石\n`）
- `saveMarks` 中带坐标的标记（中继器、供电桩）未纳入 summary

### 改动
- `scripts/dump_endfield_map_marks.py`
  - 构建 template_map 时名称统一 strip
  - 收集 all_names 时过滤空字符串
  - 新增 `_add_point` 辅助函数，同时处理 marks 与 saveMarks 中带坐标的标记（连线标记 pos=null 自动跳过）
- `scripts/dump_endfield_map_marks_public.py`
  - 同步上述三处修复
  - 修复嵌套函数 `duplicate_count` 的 UnboundLocalError（补 `nonlocal` 声明）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug 修复**
  * 优化地图标记名称处理，自动清理首尾空白并跳过空名称。
  * 忽略未知标记模板、排除项和无效坐标，提升地图标记数据的准确性与稳定性。
  * 现在可同时汇总普通标记及带坐标的保存标记，确保地图展示更完整。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->