### PR TITLE
fix: 卷不足无法购买弹性物资后，无法购买稳定物资

### DIFF
--- a/src/tasks/daily/daily_trade_mixin.py
+++ b/src/tasks/daily/daily_trade_mixin.py
@@ -377,6 +377,7 @@ class DailyTradeFeature:
                                 break
                     else:
                         self.log_info("未找到加号按钮，无法购买")
+                        self.back()
 
             if after_buy is not None:
                 after_buy(area)


### PR DESCRIPTION
修复 daily_trade_mixin 中卷不足无法购买弹性物资后，无法购买稳定物资的问题

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化购买流程：当未找到加号按钮时，自动返回当前界面并继续后续处理，避免流程停滞。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->