### PR TITLE
refactor: 跳剧情使用 click_confirm 处理弹窗点击

### DIFF
--- a/src/core/base_mixin/game_flow_mixin.py
+++ b/src/core/base_mixin/game_flow_mixin.py
@@ -163,23 +163,7 @@ class GameFlowMixin:
                 return False
             if self.find_one("skip_dialog_esc", horizontal_variance=0.05):
                 self.press_esc()
-                self.sleep(0.1)
-                start = self.active_time()
-                while self.active_time() - start < 3:
-                    self.next_frame()
-                    confirm = self.find_confirm()
-                    if confirm:
-                        self.click(confirm)
-                        if self.wait_until(
-                                lambda: not self.find_confirm(),
-                                time_out=max(0.01, min(0.8, 3 - (self.active_time() - start))),
-                                raise_if_not_found=False,
-                        ):
-                            self.log_debug("AutoSkipDialogTask confirm disappeared")
-                            return True
-                    else:
-                        self.log_debug("AutoSkipDialogTask no confirm break")
-                        return True
+                self.click_confirm()
             self.sleep(0.5)
 
     def find_confirm(self):


### PR DESCRIPTION
简化 game_flow_mixin 中跳剧情逻辑，使用 click_confirm 统一处理弹窗点击

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 优化跳过对话流程：发送 ESC 后会直接点击确认按钮，减少不必要的等待。
  * 提升跳过对话操作的响应速度与稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->