### PR TITLE
fix: 帝江号一键收集限制总等待时长

### DIFF
--- a/src/tasks/daily/misc/daily_boat_mixin.py
+++ b/src/tasks/daily/misc/daily_boat_mixin.py
@@ -37,9 +37,10 @@ class DailyBoatMixin:
     def _one_click_collect(self):
         stages = self._boat_stages()
         clue_box = self.box_of_screen(1627 / 1920, 178 / 1080, (1627 + 76) / 1920, (178 + 154) / 1080)
+        start_time= self.active_time()
         if "收集线索" in stages:
-            self.wait_click_feature(feature=fL.clue_collect_icon, box=clue_box, raise_if_not_found=False)
-        result = self.wait_click_feature(feature=fL.products_collect_icon, box=clue_box, raise_if_not_found=False)
+            self.wait_click_feature(feature=fL.clue_collect_icon, time_out=3, box=clue_box, raise_if_not_found=False)
+        result = self.wait_click_feature(feature=fL.products_collect_icon, time_out=max(1, 3 - (self.active_time() - start_time)), box=clue_box, raise_if_not_found=False)
         if result:
             self.wait_pop_up(time_out=5)
         return True


### PR DESCRIPTION
## 改动内容

`src/tasks/daily/misc/daily_boat_mixin.py` 的 `_one_click_collect()`：

- 线索收集图标点击增加 `time_out=3`，避免默认超时过长
- 记录 `start_time = self.active_time()`，产品收集图标的等待时间改为动态计算：`max(1, 3 - (self.active_time() - start_time))`

## 效果

一键收集两步等待的总时长上限约 3 秒：若线索图标已消耗等待时间，产品收集只等剩余时间（最少 1 秒），减少无可收集内容时的空等。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化一键收集流程：线索收集最多执行 3 秒，并将剩余时间分配给产品收集。
  * 为产品收集设置至少 1 秒的执行时间，提升整体操作的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->