### PR TITLE
fix: 重新生成 requirements.txt 并恢复 ok_templates 子模块指针

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,31 +24,18 @@ darkdetect==0.8.0
     # via pyside6-fluent-widgets
 idna==3.18
     # via requests
-imagehash==4.3.2
-    # via ok-end-field
-imageio==2.37.4
-    # via scikit-image
 json5==0.15.0
     # via ok-end-field
-lazy-loader==0.5
-    # via scikit-image
 mouse==0.7.1
     # via ok-script
 mouseinfo==0.1.3
     # via pyautogui
-networkx==3.6.1
-    # via scikit-image
 numpy==2.2.6
     # via
-    #   imagehash
-    #   imageio
+    #   ok-end-field
     #   opencv-python
     #   openvino
-    #   pywavelets
-    #   scikit-image
-    #   scipy
     #   shapely
-    #   tifffile
 ok-script==2.0.4
     # via ok-end-field
 onnxocr-ppocrv5==0.0.14
@@ -59,16 +46,10 @@ openvino==2026.0.0
     # via ok-end-field
 openvino-telemetry==2025.2.0
     # via openvino
-packaging==26.3
-    # via
-    #   lazy-loader
-    #   scikit-image
 pillow==12.3.0
     # via
-    #   imagehash
-    #   imageio
+    #   ok-end-field
     #   onnxocr-ppocrv5
-    #   scikit-image
 psutil==7.2.2
     # via
     #   ok-script
@@ -110,20 +91,12 @@ pysidesix-frameless-window==0.7.3
     #   pyside6-fluent-widgets
 pytweening==1.2.0
     # via pyautogui
-pywavelets==1.9.0
-    # via imagehash
 pywin32==311
     # via
     #   ok-script
     #   pysidesix-frameless-window
 requests==2.34.2
     # via ok-script
-scikit-image==0.26.0
-    # via ok-end-field
-scipy==1.18.0
-    # via
-    #   imagehash
-    #   scikit-image
 shapely==2.1.2
     # via onnxocr-ppocrv5
 shiboken6==6.11.1
@@ -132,13 +105,9 @@ shiboken6==6.11.1
 six==1.17.0
     # via
     #   pynput
-tifffile==2026.7.31
-    # via scikit-image
 typing-extensions==4.16.0
     # via ok-script
 urllib3==2.7.0
     # via requests
-websocket-client==1.9.0
-    # via ok-end-field
 websockets==15.0.1
     # via ok-end-field


### PR DESCRIPTION
## 问题

v1.0.63 / v1.0.64 两个 tag 的 Build 工作流连续失败于「Verify requirements.txt reproducible」校验，根因：

1. **#239 裁剪 imagehash/scikit-image 时未重新生成 `requirements.txt`**：`pyproject.toml` 与 `uv.lock` 已移除这些依赖，但 `requirements.txt` 仍保留（含全部传递依赖约 30 行），生成器输出与文件不一致。该校验只在 tag 构建工作流运行，master 普通 CI 不覆盖，因此直到发版才暴露。

## 修复

- 用当前 `uv.lock` 重新生成 `requirements.txt`（`uv run --locked python scripts/release/gen_release_requirements.py`），`--check` 本地验证通过
- `ok_templates` 指针恢复到 `67d132c`

## 验证

- `uv run --locked python scripts/release/gen_release_requirements.py --check` → OK
- 合并后 Auto Release 会产出 v1.0.65，Build 应转绿

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **维护**
  - 更新模板组件版本，包含最新改进。
  - 精简发布环境中的不必要组件，减少安装内容并降低潜在冲突。

- **兼容性**
  - 调整发布清单，使安装环境更加轻量，同时保持现有公开功能不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->