### PR TITLE
refactor: Feature 参数统一改用 fL 枚举引用

### DIFF
--- a/src/core/base_mixin/game_flow_mixin.py
+++ b/src/core/base_mixin/game_flow_mixin.py
@@ -161,7 +161,7 @@ class GameFlowMixin:
             if self.active_time() - start_time > time_out:
                 self.log_info("skip_dialog 超时退出")
                 return False
-            if self.find_one("skip_dialog_esc", horizontal_variance=0.05):
+            if self.find_one(fL.skip_dialog_esc, horizontal_variance=0.05):
                 self.press_esc()
                 self.click_confirm()
             self.sleep(0.5)
@@ -174,7 +174,7 @@ class GameFlowMixin:
             list: 匹配到的确认按钮结果列表。
         """
         return self.find_one(
-            "skip_dialog_confirm", horizontal_variance=0.05, vertical_variance=0.05
+            fL.skip_dialog_confirm, horizontal_variance=0.05, vertical_variance=0.05
         )
 
     def click_confirm(self, after_sleep=0, time_out=5, recheck_time=0, disappear_time_out=0.8):
@@ -241,7 +241,7 @@ class GameFlowMixin:
             bool: 找到并点击返回 True，超时返回 False。
         """
         clicked = self.click_feature(
-            feature="reward_ok",
+            fL.reward_ok,
             boxes=[self.box.bottom],
             time_out=time_out,
             after_sleep=after_sleep,
@@ -274,9 +274,9 @@ class GameFlowMixin:
                 run_at_window_pos(self.get_game_hwnd(), super().click, self.width // 2, self.height // 2, 1, 0.5, 0.5)
                 return False
             elif close := (
-                    self.find_one("one_click_claim", horizontal_variance=0.1, vertical_variance=0.1)
+                    self.find_one(fL.one_click_claim, horizontal_variance=0.1, vertical_variance=0.1)
                     or self.find_one(
-                "check_in_close",
+                fL.check_in_close,
                 horizontal_variance=0.1,
                 vertical_variance=0.1,
                 threshold=0.75,
@@ -293,7 +293,7 @@ class GameFlowMixin:
         Returns:
             list: 匹配到的奖励确认按钮结果列表。
         """
-        return self.find_one("reward_ok", vertical_variance=0.05,
+        return self.find_one(fL.reward_ok, vertical_variance=0.05,
                              box=self.box_of_screen(1760 / 3840, 1760 / 2160, 2100 / 3840, 2100 / 2160))
 
     def find_f(self):
@@ -303,7 +303,7 @@ class GameFlowMixin:
         Returns:
             list: 匹配到的 F 键提示结果列表。
         """
-        return self.find_one("pick_f", vertical_variance=0.05)
+        return self.find_one(fL.pick_f, vertical_variance=0.05)
 
     def read_essence_info(self) -> EssenceInfo | None:
         """
@@ -332,7 +332,7 @@ class GameFlowMixin:
         Returns:
             bool: 检测到战斗场景返回 True。
         """
-        in_combat_world = self.find_one("top_left_tab")
+        in_combat_world = self.find_one(fL.top_left_tab)
         if in_combat_world:
             self._logged_in = True
         return in_combat_world
@@ -386,7 +386,7 @@ class GameFlowMixin:
         Returns:
             bool: 当前处于游戏世界返回 True。
         """
-        main_world_features = ["esc"]
+        main_world_features = [fL.esc]
 
         in_world = all(self.find_one(f, vertical_variance=0.01, horizontal_variance=0.02) for f in main_world_features)
 

--- a/src/tasks/daily/daily_credit_mixin.py
+++ b/src/tasks/daily/daily_credit_mixin.py
@@ -55,7 +55,7 @@ class DailyCreditMixin:
                     return False
                 if left_exchange_time > 0:
                     result = self.find_feature(
-                        feature="can_exchange_info_icon", box=span_box
+                        feature=fL.can_exchange_info_icon, box=span_box
                     )
                     if scroll_count >= 7:
                         self.back()
@@ -67,7 +67,7 @@ class DailyCreditMixin:
                         continue
                 elif left_help_time > 0:
                     result = self.find_feature(
-                        feature="can_help_icon", box=span_box
+                        feature=fL.can_help_icon, box=span_box
                     )
                 if not result:
                     scroll_count += 1

--- a/src/tasks/daily/misc/daily_reward_mixin.py
+++ b/src/tasks/daily/misc/daily_reward_mixin.py
@@ -144,7 +144,7 @@ class DailyRewardMixin:
         )
 
         if result := self.find_one(
-                feature="claim_gift", box=self.box.left, threshold=0.8
+                feature=fL.claim_gift, box=self.box.left, threshold=0.8
         ):
             self.log_info("发现可领取的额外奖励，点击领取")
             self.click(result)

--- a/src/tasks/mixin/battle_mixin.py
+++ b/src/tasks/mixin/battle_mixin.py
@@ -252,7 +252,7 @@ class BattleMixin(BaseEfTask):
         """
         使用连携技能。
         """
-        if self.find_one("default_link_skill", threshold=0.7, vertical_variance=0.005, horizontal_variance=0.005):
+        if self.find_one(fL.default_link_skill, threshold=0.7, vertical_variance=0.005, horizontal_variance=0.005):
             self.press_combat_key("e")
             return True
 
@@ -287,7 +287,7 @@ class BattleMixin(BaseEfTask):
         skill_checks = []
         boxes = self._battle_feature_boxes("skill")
         for box_index, box in enumerate(boxes, start=1):
-            result = self.find_one("skill_1", box=box)
+            result = self.find_one(fL.skill_1, box=box)
             match_position = f"({result.x},{result.y})" if result is not None else "-"
             match_score = f"{result.confidence:.3f}" if result is not None else "-"
             skill_checks.append(

--- a/src/tasks/mixin/liaison_mixin.py
+++ b/src/tasks/mixin/liaison_mixin.py
@@ -110,7 +110,7 @@ class LiaisonMixin(NavigationMixin):
 
         # 查找传送点
         tp_icon = self.find_feature(
-            feature="transfer_point",
+            feature=fL.transfer_point,
             box=box,
             threshold=0.7
         )
@@ -206,7 +206,7 @@ class LiaisonMixin(NavigationMixin):
             在导航过程中检测是否出现干员交互图标
             """
 
-            chat_box = self.find_feature("chat_icon_dark") or self.find_feature("chat_icon_2")
+            chat_box = self.find_feature(fL.chat_icon_dark) or self.find_feature(fL.chat_icon_2)
 
             if chat_box:
                 self.send_key_up("w")  # 确认使用send_key：释放方向键（W为移动键，不属于可配置热键）

--- a/src/tasks/mixin/map_mixin.py
+++ b/src/tasks/mixin/map_mixin.py
@@ -31,7 +31,7 @@ class MapMixin(BaseEfTask):
 
         # 查找“任务定位到地图”按钮
         result = self.wait_feature(
-            feature="one_task_to_map",
+            feature=fL.one_task_to_map,
             threshold=0.8,
             box=self.box.bottom_right,
             time_out=4,

--- a/src/tasks/onetime/AutoCombatLogic.py
+++ b/src/tasks/onetime/AutoCombatLogic.py
@@ -9,6 +9,7 @@ from src.core.BattleConfig import (
     KEY_INSTANT_ULT,
 )
 from src.core.rotation_ast import iter_actions, normalize_ast
+from src.data.FeatureList import FeatureList as fL
 
 
 class _TaskProbe:
@@ -24,7 +25,7 @@ class _TaskProbe:
     def link_available(self) -> bool:
         # 对应 battle_mixin.use_link_skill 的检测参数
         return bool(self._task.find_one(
-            "default_link_skill", threshold=0.7, vertical_variance=0.005, horizontal_variance=0.005
+            fL.default_link_skill, threshold=0.7, vertical_variance=0.005, horizontal_variance=0.005
         ))
 
     def skill_count(self) -> int:


### PR DESCRIPTION
## 概述

基于 AST 扫描(结合函数签名 + FeatureList 枚举成员判定,非变量名猜测)定位全部 Feature 传参场景,把与枚举成员一致的硬编码字符串统一替换为 `fL.*` 引用。

**16 处 / 7 个文件**,`py_compile` 与相关单元测试(27 个)全部通过。

## 转换明细

| 文件 | 场景 | 转换 |
|---|---|---|
| `src/core/base_mixin/game_flow_mixin.py` | 位置参数 / 集合 | `skip_dialog_esc`、`skip_dialog_confirm`、`one_click_claim`、`check_in_close`、`reward_ok`、`pick_f`、`top_left_tab`,`in_world` 的 `["esc"]` → `[fL.esc]` |
| `src/tasks/daily/daily_credit_mixin.py` | 显式 `feature=` | `can_exchange_info_icon`、`can_help_icon` |
| `src/tasks/daily/misc/daily_reward_mixin.py` | 显式 `feature=` | `claim_gift` |
| `src/tasks/mixin/battle_mixin.py` | 位置参数 | `default_link_skill`、`skill_1` |
| `src/tasks/mixin/liaison_mixin.py` | 混合 | `transfer_point`、`chat_icon_dark`、`chat_icon_2` |
| `src/tasks/mixin/map_mixin.py` | 显式 `feature=` | `one_task_to_map` |
| `src/tasks/onetime/AutoCombatLogic.py` | 多层调用链(`_TaskProbe` 转发) | `default_link_skill`(补 `fL` import) |

## 刻意保留(待人工确认)

- **动态拼接**(运行时构造,对应值均存在于 fL):`battle_mixin` 的 `"ult_" + ult`、`f"skill_{n}"`;`daily_boat_mixin` 的 `f"clue_{i}_icon"`;`AutoCombatLogic` 的 `"ult_" + str(n)`
- **数据/配置驱动**:`WarehouseTransferTask` 物品图标名、`map_mixin` 的 `need_reserve_icon_name` 参数;`daily_battle_mixin` 的 `"battle_end"` 为 YOLO 模型类别名(不在 FeatureList 中)
- **测试桩/断言**:`TestRuntimeMixinFeatureClick` 合成名、`TestStateDrivenWaits` fake task;`TestDeliveryAreaConfig` 断言原始字符串与 `fL` 成员恒等(`str` 枚举),无需改动

## 验证

- [x] AST 复扫:A 类硬编码清零
- [x] 全局搜索 `feature="` / `click_feature(` / `wait_feature(` / `find_feature(` 无生产代码残留
- [x] `py_compile` 7 个文件通过
- [x] `tests.TestStateDrivenWaits` / `TestRuntimeMixinFeatureClick` / `TestDeliveryAreaConfig` 共 27 个测试 OK


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 统一游戏流程、日常任务、战斗和地图操作中的界面元素识别方式。
  * 提升对对话、奖励、登录弹窗、签到、拾取提示、技能及交互图标等场景的识别一致性。
  * 保持现有操作流程、判断条件和错误处理行为不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->