### PR TITLE
fix: 后台模式切换账号后恢复原前台窗口

### DIFF
--- a/src/core/BaseEfTask.py
+++ b/src/core/BaseEfTask.py
@@ -34,13 +34,18 @@ _ok_screenshot.get_current_time_formatted = lambda: datetime.now().strftime("%Y%
 
 
 def back_window(prev):
+    """尝试将前台窗口恢复为 prev，返回是否实际完成恢复。"""
     current = win32gui.GetForegroundWindow()
 
-    if prev and win32gui.IsWindow(prev) and current != prev:
-        try:
-            win32gui.SetForegroundWindow(prev)
-        except Exception:
-            pass
+    if not prev or not win32gui.IsWindow(prev) or current == prev:
+        return False
+
+    try:
+        win32gui.SetForegroundWindow(prev)
+    except Exception:
+        return False
+
+    return win32gui.GetForegroundWindow() == prev
 
 
 def _extract_locale_from_object(obj: Any) -> str | None:

--- a/src/tasks/mixin/login_mixin.py
+++ b/src/tasks/mixin/login_mixin.py
@@ -59,30 +59,33 @@ class LoginMixin(BaseEfTask):
             raise RuntimeError("未找到登出按钮，可能没有先登录，请先登录任意账号")
         self.click(result)
         # 前置动作：后续「最近/账号/登录」点击走 pyautogui（只作用于前台窗口），
-        # 必须先把游戏窗口置前；后台模式下先记录切换前的前台窗口，点击登录后恢复。
+        # 必须先把游戏窗口置前；后台模式下先记录切换前的前台窗口，交互结束后恢复。
         prev_hwnd = None
         if self.input_mode() == "background":
             prev_hwnd = win32gui.GetForegroundWindow()
-        self.active_and_send_mouse_delta(0, 0, activate=True, only_activate=True)
-        if not self.wait_click_feature(feature=fL.log_out_confirm, time_out=5, raise_if_not_found=False):  # 点击登出确认
-            self.log_error("未找到登出确认按钮")
-            return False
-        self._logged_in = False
-        result = self.click_text(re.compile("最近"), box=self.box.center, success_match=self.lang.login_mixin.k_20275ef2,
-                                 need_wait_disappear=False)  # 点击当前账号（假设是唯一的）"最近", box=self.box.center, need_wait_disappear=False)  # 点击当前账号（假设是唯一的）
-        if not result:
-            self.log_error("未找到‘最近’按钮，可能未成功返回登录界面")
-            raise RuntimeError("未找到‘最近’按钮，可能未成功返回登录界面")
-        self.click_text(re.compile(username[-4:]),
-                        box=self.box_of_screen(0, (result[0].y + result[0].height) / self.height, 1,
-                                               1))  # 点击最近登录的账号（假设是唯一的）
-        self.click_text("登录", box=self.box.center)  # 点击登录按钮
-        # 后台模式：点击登录后不再有前台点击（后续仅轮询截图确认登录），
-        # 恢复切换账号前的前台窗口，避免游戏一直霸占前台。
-        if prev_hwnd is not None:
-            back_window(prev_hwnd)
-            prev_hwnd = None
-            self.log_info("后台模式：已恢复切换账号前的前台窗口")
+        try:
+            self.active_and_send_mouse_delta(0, 0, activate=True, only_activate=True)
+            if not self.wait_click_feature(feature=fL.log_out_confirm, time_out=5, raise_if_not_found=False):  # 点击登出确认
+                self.log_error("未找到登出确认按钮")
+                return False
+            self._logged_in = False
+            result = self.click_text(re.compile("最近"), box=self.box.center, success_match=self.lang.login_mixin.k_20275ef2,
+                                     need_wait_disappear=False)  # 点击当前账号（假设是唯一的）"最近", box=self.box.center, need_wait_disappear=False)  # 点击当前账号（假设是唯一的）
+            if not result:
+                self.log_error("未找到‘最近’按钮，可能未成功返回登录界面")
+                raise RuntimeError("未找到‘最近’按钮，可能未成功返回登录界面")
+            self.click_text(re.compile(username[-4:]),
+                            box=self.box_of_screen(0, (result[0].y + result[0].height) / self.height, 1,
+                                                   1))  # 点击最近登录的账号（假设是唯一的）
+            self.click_text("登录", box=self.box.center)  # 点击登录按钮
+        finally:
+            # 后台模式：点击登录后不再有前台点击（后续仅轮询截图确认登录），
+            # 无论正常走完、提前返回还是中途异常都恢复切换账号前的前台窗口，避免游戏霸占前台。
+            if prev_hwnd is not None:
+                if back_window(prev_hwnd):
+                    self.log_info("后台模式：已恢复切换账号前的前台窗口")
+                else:
+                    self.log_debug("后台模式：无需恢复或未能恢复切换账号前的前台窗口")
         if not self._confirm_logged_in():
             raise RuntimeError("登录失败")
 

--- a/src/tasks/mixin/login_mixin.py
+++ b/src/tasks/mixin/login_mixin.py
@@ -1,6 +1,8 @@
 import re
+
 import pyautogui
-from src.core.BaseEfTask import BaseEfTask
+import win32gui
+from src.core.BaseEfTask import BaseEfTask, back_window
 from src.data.FeatureList import FeatureList as fL
 from src.interaction.Mouse import run_at_window_pos
 from ok import Box
@@ -56,6 +58,11 @@ class LoginMixin(BaseEfTask):
         if not result:
             raise RuntimeError("未找到登出按钮，可能没有先登录，请先登录任意账号")
         self.click(result)
+        # 前置动作：后续「最近/账号/登录」点击走 pyautogui（只作用于前台窗口），
+        # 必须先把游戏窗口置前；后台模式下先记录切换前的前台窗口，点击登录后恢复。
+        prev_hwnd = None
+        if self.input_mode() == "background":
+            prev_hwnd = win32gui.GetForegroundWindow()
         self.active_and_send_mouse_delta(0, 0, activate=True, only_activate=True)
         if not self.wait_click_feature(feature=fL.log_out_confirm, time_out=5, raise_if_not_found=False):  # 点击登出确认
             self.log_error("未找到登出确认按钮")
@@ -70,6 +77,12 @@ class LoginMixin(BaseEfTask):
                         box=self.box_of_screen(0, (result[0].y + result[0].height) / self.height, 1,
                                                1))  # 点击最近登录的账号（假设是唯一的）
         self.click_text("登录", box=self.box.center)  # 点击登录按钮
+        # 后台模式：点击登录后不再有前台点击（后续仅轮询截图确认登录），
+        # 恢复切换账号前的前台窗口，避免游戏一直霸占前台。
+        if prev_hwnd is not None:
+            back_window(prev_hwnd)
+            prev_hwnd = None
+            self.log_info("后台模式：已恢复切换账号前的前台窗口")
         if not self._confirm_logged_in():
             raise RuntimeError("登录失败")
 


### PR DESCRIPTION
## 改动内容

后台模式（伪后台）下多账号切换时，`login_flow` 的前置动作会把游戏窗口强制置前（后续「最近/账号/登录」点击走 pyautogui，只作用于前台窗口），但登录完成后从未恢复，导致游戏一直霸占前台。

本次修改 `src/tasks/mixin/login_mixin.py`：

1. **置前动作前**：仅当 `input_mode() == "background"` 时记录当前前台窗口句柄 `prev_hwnd`；
2. **点击「登录」之后**：此时已无任何前台点击需求（后续 `_confirm_logged_in` 仅轮询截图确认登录），调用已有的 `back_window(prev)` 恢复切换前的前台窗口并输出日志。

## 行为说明

- 前台模式行为完全不变；
- 切换前游戏本就在前台时，恢复逻辑自动空操作（`back_window` 内部有 `current != prev` 与 `IsWindow` 校验）；
- 复用 `BaseEfTask.back_window` 辅助函数（此前已定义但从未被调用）。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **功能优化**
  * 优化后台输入模式下的登录流程，提升操作稳定性。
  * 完成登出、账号切换或登录操作后，自动尝试恢复操作前的前台窗口。
  * 恢复结果将得到确认并记录，异常情况下也会执行恢复处理。
  * 其他登录模式保持原有行为不变。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->