### PR TITLE
refactor: 动态值日志统一 tr+format 并清理 runtime_mixin 冗余封装

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -86,4 +86,5 @@ gh pr edit <n> --body $body
 3. **动态配置用声明式豁免（治本）**：用户输入载入的下拉配置（如「地图账号」= 账号列表）不参与翻译——把 config key 登记到 `src/core/dynamic_config_keys.py` 的 `DYNAMIC_DROPDOWN_KEYS`，渲染补丁 `dynamic_config_patch.py` 据此跳过 tr。**项目资源类下拉不要登记**（干员列表 characters.json、物品导航「选择物品」等是合法待翻译文案）。
 4. 框架无单条豁免参数；`to_translate` 仅 debug 模式启用，生产不受影响，垃圾条目对运行无害但会膨胀 po、误导翻译。
 5. `log_info`/`mark_task_failure` 自身不做翻译也不支持 params 填充；**带动态值的日志统一在调用侧走 tr+format**：`self.tr("模板{a}…{b}").format(a=已译文本值, b=纯数字值)`——外层模板串必须 tr（msgid=稳定模板串进 po），文本类动态值内层过 tr 后再填充，纯数字值直接填充不 tr；运行时未知文本（OCR 结果、账号名等）不过 tr 防污染收集池。通知链路（`notify=True`/`show_notification`）和 instructions 富文本构建同理。
+   **纯静态硬编码文案（无占位符、无变化）禁止在调用侧加 tr**：直接 `log_info("固定中文")`——UI 显示层渲染日志时会统一翻译，调用侧再包一层 tr 属于冗余；只有带占位符、存在多种变化的模板串才需要调用侧 tr+format（gettext 必须在 format 前命中稳定 msgid）。
 6. po 出现垃圾条目时：确认来源 → 能声明式的走第 3 条；一次性清理可仿照 `tmp/clean_dynamic_po_entries.py` 删条目后重编译。

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -85,5 +85,5 @@ gh pr edit <n> --body $body
 2. **`re.Pattern` 进日志前必须取 `.pattern`**：f-string 直接拼 Pattern 对象会 str 化为 `re.compile('xxx')`（见 `login_mixin.click_text` 的规范化写法）。
 3. **动态配置用声明式豁免（治本）**：用户输入载入的下拉配置（如「地图账号」= 账号列表）不参与翻译——把 config key 登记到 `src/core/dynamic_config_keys.py` 的 `DYNAMIC_DROPDOWN_KEYS`，渲染补丁 `dynamic_config_patch.py` 据此跳过 tr。**项目资源类下拉不要登记**（干员列表 characters.json、物品导航「选择物品」等是合法待翻译文案）。
 4. 框架无单条豁免参数；`to_translate` 仅 debug 模式启用，生产不受影响，垃圾条目对运行无害但会膨胀 po、误导翻译。
-5. `log_info`/`mark_task_failure` 自身不做翻译也不支持 params 填充；`tr+format` 仅用于通知链路（`notify=True`/`show_notification`）和 instructions 富文本构建。
+5. `log_info`/`mark_task_failure` 自身不做翻译也不支持 params 填充；**带动态值的日志统一在调用侧走 tr+format**：`self.tr("模板{a}…{b}").format(a=已译文本值, b=纯数字值)`——外层模板串必须 tr（msgid=稳定模板串进 po），文本类动态值内层过 tr 后再填充，纯数字值直接填充不 tr；运行时未知文本（OCR 结果、账号名等）不过 tr 防污染收集池。通知链路（`notify=True`/`show_notification`）和 instructions 富文本构建同理。
 6. po 出现垃圾条目时：确认来源 → 能声明式的走第 3 条；一次性清理可仿照 `tmp/clean_dynamic_po_entries.py` 删条目后重编译。

--- a/src/core/BaseEfTask.py
+++ b/src/core/BaseEfTask.py
@@ -445,11 +445,15 @@ class BaseEfTask(
                 username = str(account.get("username", "")).strip()
                 account_id = str(account.get("account_id", "")).strip() or username
                 if not username:
-                    self.log_info(f"第 {repeat_idx + 1}/{repeat_times} 个账号为空，已跳过")
+                    # 纯数字值直接填充不 tr，模板串过 tr
+                    self.log_info(self.tr("第 {idx}/{total} 个账号为空，已跳过").format(
+                        idx=repeat_idx + 1, total=repeat_times))
                     continue
 
                 self.set_current_account(username, account_id)
-                self.log_info(f"开始第 {repeat_idx + 1}/{repeat_times} 个账号({username[-4:]}){account_log_suffix}")
+                # 账号后缀是运行时用户数据不过 tr（防污染收集池）；模板串过 tr
+                self.log_info(self.tr("开始第 {idx}/{total} 个账号({suffix}){log_suffix}").format(
+                    idx=repeat_idx + 1, total=repeat_times, suffix=username[-4:], log_suffix=account_log_suffix))
                 self.login_flow(username)
             else:
                 self.set_current_account("", "")

--- a/src/core/base_mixin/game_flow_mixin.py
+++ b/src/core/base_mixin/game_flow_mixin.py
@@ -353,7 +353,7 @@ class GameFlowMixin:
             Exception: 当无法回到主界面时抛出。
         """
         self.check_resolution()
-        self.info_set("current task", f"wait main esc={esc}")
+        self.info_set("current task", self.tr("wait main esc={esc}").format(esc=esc))
         start = self.active_time()
         observe_time = min(2.0, time_out)
 
@@ -377,7 +377,7 @@ class GameFlowMixin:
             raise Exception("Please start in game world and in team!")
         if after_sleep > 0:
             self.sleep(after_sleep)
-        self.info_set("current task", f"in main esc={esc}")
+        self.info_set("current task", self.tr("in main esc={esc}").format(esc=esc))
 
     def in_world(self):
         """
@@ -514,7 +514,7 @@ class GameFlowMixin:
         self.press_key("i")
         results = self.wait_feature(feature=fL.operation_report_icon, time_out=time_out, raise_if_not_found=False)
         if results:
-            self.log_info(f"已进入房间列表")
+            self.log_info("已进入房间列表")
             return True
 
         self.log_info("未识别到房间列表")

--- a/src/core/base_mixin/process_manager.py
+++ b/src/core/base_mixin/process_manager.py
@@ -13,11 +13,12 @@ class ProcessManager:
                 handle = win32api.OpenProcess(win32con.PROCESS_TERMINATE, False, pid)
                 win32api.TerminateProcess(handle, 0)
                 win32api.CloseHandle(handle)
-                self.log_info(f"已终止进程 pid={pid}", notify=True)
+                self.log_info(self.tr("已终止进程 pid={pid}").format(pid=pid), notify=True)
             else:
                 self.log_info("未获取到 hwnd，无法终止进程", notify=True)
         except Exception as e2:
-            self.log_info(f"终止进程失败: {e2}", notify=True)
+            # 异常消息是运行时文本不过 tr
+            self.log_info(self.tr("终止进程失败: {err}").format(err=e2), notify=True)
 
     def kill_all_related_processes(self):
         """尝试杀死游戏进程和本软件自身进程（除当前进程外）"""
@@ -30,11 +31,11 @@ class ProcessManager:
                 handle = win32api.OpenProcess(win32con.PROCESS_TERMINATE, False, pid)
                 win32api.TerminateProcess(handle, 0)
                 win32api.CloseHandle(handle)
-                self.log_info(f"已终止游戏进程 pid={pid}", notify=True)
+                self.log_info(self.tr("已终止游戏进程 pid={pid}").format(pid=pid), notify=True)
             else:
                 self.log_info("未获取到 hwnd，无法终止游戏进程", notify=True)
         except Exception as e:
-            self.log_info(f"终止游戏进程失败: {e}", notify=True)
+            self.log_info(self.tr("终止游戏进程失败: {err}").format(err=e), notify=True)
         # 2. 杀死本软件所有同名进程（除当前进程）
         try:
             current_pid = os.getpid()
@@ -43,8 +44,8 @@ class ProcessManager:
                 if proc.info["name"] == exe_name and proc.info["pid"] != current_pid:
                     try:
                         proc.kill()
-                        self.log_info(f"已终止本软件进程 pid={proc.info['pid']}", notify=True)
+                        self.log_info(self.tr("已终止本软件进程 pid={pid}").format(pid=proc.info['pid']), notify=True)
                     except Exception as e2:
-                        self.log_info(f"终止本软件进程失败: {e2}", notify=True)
+                        self.log_info(self.tr("终止本软件进程失败: {err}").format(err=e2), notify=True)
         except Exception as e:
-            self.log_info(f"查找/终止本软件进程失败: {e}", notify=True)
+            self.log_info(self.tr("查找/终止本软件进程失败: {err}").format(err=e), notify=True)

--- a/src/core/base_mixin/runtime_mixin.py
+++ b/src/core/base_mixin/runtime_mixin.py
@@ -438,7 +438,7 @@ class RuntimeMixin:
         while True:
             # 检查是否已超时
             if self.active_time() - start_time > time_out:
-                self.log_info(f"safe_back 超时（{time_out}s），目标未出现")
+                self.log_info(self.tr("safe_back 超时（{time_out}s），目标未出现").format(time_out=time_out))
                 return False
 
             remaining = time_out - (self.active_time() - start_time)
@@ -632,7 +632,7 @@ class RuntimeMixin:
             detections = detector.detect(detect_frame, threshold=conf)
         detections = detections or []
 
-        self.log_info(f"yolo_detect: raw detections count = {len(detections)}")
+        self.log_info(self.tr("yolo_detect: raw detections count = {count}").format(count=len(detections)))
         raw_results: list[Box] = []
         filtered_results: list[Box] = []
 
@@ -641,7 +641,8 @@ class RuntimeMixin:
                 continue
             det_name = getattr(det, "name", None)
             det_conf = float(getattr(det, "confidence", 0.0) or 0.0)
-            self.log_info(f"Raw detection: name={det_name}, conf={det_conf:.3f}")
+            # 检测名是模型输出运行时文本不过 tr
+            self.log_info(self.tr("Raw detection: name={name}, conf={conf:.3f}").format(name=det_name, conf=det_conf))
 
             new_box = Box(
                 int(det.x + offset_x),
@@ -663,7 +664,7 @@ class RuntimeMixin:
             self.draw_boxes(f"yolo_raw_{debug_tag}", raw_results, color="yellow", debug=debug_overlay_enabled)
             self.draw_boxes(f"yolo_filtered_{debug_tag}", filtered_results, color="red", debug=debug_overlay_enabled)
 
-        self.log_info(f"yolo_detect: filtered detections count = {len(filtered_results)}")
+        self.log_info(self.tr("yolo_detect: filtered detections count = {count}").format(count=len(filtered_results)))
 
         return sorted(filtered_results, key=lambda item: item.confidence, reverse=True)
 
@@ -1193,90 +1194,5 @@ class RuntimeMixin:
                 self.click(result, after_sleep=after_sleep)
             return result
 
-        self.log_info(f"wait ocr no box {x} {y} {width} {height} {to_x} {to_y} {match}")
-
-    def screen_center(self) -> tuple[int, int]:
-        """
-        返回当前屏幕中心点坐标。
-
-        Returns:
-            tuple[int, int]: 屏幕中心点坐标。
-        """
-        return int(self.width / 2), int(self.height / 2)
-
-    def find_one(self, feature_name=None, horizontal_variance=0, vertical_variance=0, threshold=0,
-             use_gray_scale=False, box=None, canny_lower=0, canny_higher=0,
-             frame_processor=None, template=None, mask_function=None, frame=None,
-             match_method=cv2.TM_CCOEFF_NORMED, screenshot=False, limit=1,
-             target_height=0, feature=None):
-        """
-        按当前分辨率执行单个特征识别。
-
-        本方法为父类 ``find_one()`` 的兼容封装，支持使用 ``feature`` 作为
-        ``feature_name`` 的别名。特征名称映射逻辑由底层 ``find_feature()`` 统一处理。
-
-        Args:
-            feature_name: 特征名称。
-            horizontal_variance: 水平容差。
-            vertical_variance: 垂直容差。
-            threshold: 匹配阈值。
-            use_gray_scale: 是否使用灰度图匹配。
-            box: 识别区域。
-            canny_lower: Canny 边缘检测下限阈值。
-            canny_higher: Canny 边缘检测上限阈值。
-            frame_processor: 额外图像处理函数。
-            template: 自定义模板图像。
-            mask_function: 掩码处理函数。
-            frame: 输入图像，为 None 时自动截图。
-            match_method: OpenCV 模板匹配方法。
-            screenshot: 是否强制重新截图。
-            limit: 最大返回结果数量。
-            target_height: 匹配前缩放到指定高度，0 表示不缩放。
-            feature: ``feature_name`` 的兼容别名。
-
-        Returns:
-            Box: 匹配到的第一个结果；未匹配到时返回空 Box 或 None（取决于父类实现）。
-        """
-        if feature_name is None and feature is not None:
-            feature_name = feature
-        return super().find_one(feature_name, horizontal_variance, vertical_variance, threshold,
-                                use_gray_scale, box, canny_lower, canny_higher, frame_processor,
-                                template, mask_function, frame, match_method, screenshot,
-                                limit, target_height)
-    def send_key(
-        self,
-        key,
-        down_time=0.1,
-        interval=0,
-        after_sleep=0
-    ):
-        """
-        Sends a key event.
-
-        发送键事件。
-
-        Parameters
-        ----------
-        key:
-            Key to send. 要发送的键。
-
-        down_time:
-            Down time. 按下时间。
-
-        interval:
-            Interval check. 间隔检查。
-
-        after_sleep:
-            Sleep after. 后睡眠。
-
-        Returns
-        -------
-        bool:
-            True if sent. 如果发送返回 True。
-        """
-        return super().send_key(
-            key,
-            down_time,
-            interval,
-            after_sleep
-        )
+        self.log_info(self.tr("wait ocr no box {x} {y} {width} {height} {to_x} {to_y} {match}").format(
+            x=x, y=y, width=width, height=height, to_x=to_x, to_y=to_y, match=getattr(match, "pattern", match)))

--- a/src/core/base_mixin/runtime_mixin.py
+++ b/src/core/base_mixin/runtime_mixin.py
@@ -1194,5 +1194,10 @@ class RuntimeMixin:
                 self.click(result, after_sleep=after_sleep)
             return result
 
+        # match 支持 str / re.Pattern / list，逐项取 .pattern 防止日志出现 re.compile(...)
+        if isinstance(match, (list, tuple)):
+            match_text = [getattr(m, "pattern", m) for m in match]
+        else:
+            match_text = getattr(match, "pattern", match)
         self.log_info(self.tr("wait ocr no box {x} {y} {width} {height} {to_x} {to_y} {match}").format(
-            x=x, y=y, width=width, height=height, to_x=to_x, to_y=to_y, match=getattr(match, "pattern", match)))
+            x=x, y=y, width=width, height=height, to_x=to_x, to_y=to_y, match=match_text))

--- a/src/tasks/account/account_mixin.py
+++ b/src/tasks/account/account_mixin.py
@@ -54,7 +54,8 @@ class AccountMixin(LoginMixin):
             username = line.split(",", 1)[0].strip() if "," in line else line.strip()  # ✅ 兼容只有账号的情况
 
             if not username:
-                self.log_info(f"账号格式错误，已跳过: {line}")
+                # 行内容是用户配置运行时文本不过 tr
+                self.log_info(self.tr("账号格式错误，已跳过: {line}").format(line=line))
                 continue
 
             account_id = resolve_account_id(username, create_if_missing=False)

--- a/src/tasks/daily/daily_buy_mixin.py
+++ b/src/tasks/daily/daily_buy_mixin.py
@@ -44,7 +44,8 @@ class DailyBuyFeature:
         for area in target_areas:
             if not keep_area_context:
                 self.ensure_main()
-            self.log_info(f"进入区域: {area}")
+            # 区域名是项目静态常量，文本值内层过 tr
+            self.log_info(self.tr("进入区域: {area}").format(area=self.tr(area)))
             #
             self.wait_click_ocr(
                 match=self.lang.daily_buy_mixin.stable_materials_tab,

--- a/src/tasks/daily/daily_buy_mixin.py
+++ b/src/tasks/daily/daily_buy_mixin.py
@@ -44,7 +44,7 @@ class DailyBuyFeature:
         for area in target_areas:
             if not keep_area_context:
                 self.ensure_main()
-            # 区域名是项目静态常量，文本值内层过 tr
+            # 区域名是项目静态常量（po 已有正式 msgid），文本值内层过 tr
             self.log_info(self.tr("进入区域: {area}").format(area=self.tr(area)))
             #
             self.wait_click_ocr(

--- a/src/tasks/daily/daily_credit_mixin.py
+++ b/src/tasks/daily/daily_credit_mixin.py
@@ -1,4 +1,3 @@
-
 from src.data.FeatureList import FeatureList as fL
 
 
@@ -88,7 +87,9 @@ class DailyCreditMixin:
                 actions.append("交流")
             if left_help_time > 0:
                 actions.append("助力")
-            self.log_info(f"已进入好友帝江号，准备进行{''.join(actions)}操作")
+            # 「交流」「助力」为静态文案，内层逐个过 tr 后拼接
+            self.log_info(self.tr("已进入好友帝江号，准备进行{actions}操作").format(
+                actions=''.join(self.tr(a) for a in actions)))
             self.press_key("y")
             self.wait_ui_stable(refresh_interval=1)
             if left_exchange_time > 0:

--- a/src/tasks/daily/daily_demo_mixin.py
+++ b/src/tasks/daily/daily_demo_mixin.py
@@ -155,7 +155,7 @@ class DailyDemoFeature:
         changed = {"level": None}
 
         def level_changed():
-            result = self.find_one(feature=fL.level_tip, box=self._level_tip_box())
+            result = self.find_one(fL.level_tip, box=self._level_tip_box())
             if not result:
                 return False
             current = self._level_from_tip(result)
@@ -178,8 +178,10 @@ class DailyDemoFeature:
         level_x = result.x 
         one_level_width = (end_x - start_x) / level_all #每个等级占的宽度占屏幕宽度的比例
         level = int((level_x - self.screen_width * start_x) / (self.screen_width * one_level_width)) #根据等级信息标志的x坐标计算当前等级
-        self.log_info(f"当前等级: {level}")
-        self.log_info(
-            f"x={level_x}, ratio={(level_x - self.screen_width * start_x) / (self.screen_width * one_level_width):.2f}, level={level}"
-        )
+        self.log_info(self.tr("当前等级: {level}").format(level=level))
+        self.log_info(self.tr("x={x}, ratio={ratio:.2f}, level={level}").format(
+            x=level_x,
+            ratio=(level_x - self.screen_width * start_x) / (self.screen_width * one_level_width),
+            level=level
+        ))
         return level

--- a/src/tasks/daily/daily_liaison_mixin.py
+++ b/src/tasks/daily/daily_liaison_mixin.py
@@ -111,7 +111,7 @@ class DailyLiaisonFeature:
         retry = 0
         result = self.navigate_to_operator_liaison_station()
         while result == LiaisonResult.FIND_CHAT_ICON:
-            self.log_info(f"聊天界面处理 (第 {retry + 1}/{max_retry} 次)")
+            self.log_info(self.tr("聊天界面处理 (第 {idx}/{total} 次)").format(idx=retry + 1, total=max_retry))
 
             if self.collect_and_give_gifts():
                 return True
@@ -143,14 +143,14 @@ class DailyLiaisonFeature:
         max_retry = self.config.get(self.CFG_GIFT_MAX_RETRY, 1)
 
         for i in range(max_retry):
-            self.log_info(f"送礼任务 - 第 {i + 1}/{max_retry} 次尝试")
+            self.log_info(self.tr("送礼任务 - 第 {idx}/{total} 次尝试").format(idx=i + 1, total=max_retry))
 
             success = self.execute_gift_to_liaison()
             if success:
-                self.log_info(f"第 {i + 1} 次送礼任务成功")
+                self.log_info(self.tr("第 {idx} 次送礼任务成功").format(idx=i + 1))
                 return True
 
-            self.log_info(f"第 {i + 1} 次送礼任务失败")
+            self.log_info(self.tr("第 {idx} 次送礼任务失败").format(idx=i + 1))
 
         self.mark_task_failure("送礼任务最终失败")
         return False

--- a/src/tasks/daily/daily_regional_runner.py
+++ b/src/tasks/daily/daily_regional_runner.py
@@ -23,13 +23,13 @@ class DailyRegionalRunner:
         enabled_trade = "买卖货" in selected
 
         for area in areas_list:
-            self.log_info(f"开始处理地区建设: {area}")
+            self.log_info(self.tr("开始处理地区建设: {area}").format(area=self.tr(area)))
             if enabled_outpost:
                 if not self._task.daily_routine.exchange_outpost_goods(
                     target_areas=[area],
                     keep_area_context=True,
                 ):
-                    self.log_info(f"据点兑换失败: {area}")
+                    self.log_info(self.tr("据点兑换失败: {area}").format(area=self.tr(area)))
 
             if enabled_trade:
                 # 买卖货：买入后通过 after_buy 回调执行「买物资」。
@@ -43,7 +43,7 @@ class DailyRegionalRunner:
                     after_buy=self._buy_staple_after_trade if enabled_buy else None,
                 )
                 if not trade_ok:
-                    self.log_info(f"买卖货失败: {area}")
+                    self.log_info(self.tr("买卖货失败: {area}").format(area=self.tr(area)))
                 if enabled_buy and not self._buy_ran:
                     self.log_info("买卖货未执行买物资回调，单独执行买物资")
                     self._buy_staple_in_area(area)
@@ -52,7 +52,7 @@ class DailyRegionalRunner:
                 self._buy_staple_in_area(area)
 
             self.safe_back(feature=fL.transaction_overview, once_time_out=3)
-            self.log_info(f"完成地区建设: {area}")
+            self.log_info(self.tr("完成地区建设: {area}").format(area=self.tr(area)))
 
         return True
 
@@ -67,11 +67,11 @@ class DailyRegionalRunner:
     def _buy_staple_in_area(self, area):
         """进入物资调度后执行「买物资」。"""
         if not self._task.to_model_area(area, "物资调度"):
-            self.log_info(f"无法进入{area}物资调度，跳过买物资")
+            self.log_info(self.tr("无法进入{area}物资调度，跳过买物资").format(area=self.tr(area)))
             return False
         if not self._task.daily_buy.buy_staple_goods(
             target_areas=[area],
             keep_area_context=True,
         ):
-            self.log_info(f"买物资失败: {area}")
+            self.log_info(self.tr("买物资失败: {area}").format(area=self.tr(area)))
         return True

--- a/src/tasks/daily/daily_shop_mixin.py
+++ b/src/tasks/daily/daily_shop_mixin.py
@@ -6,7 +6,9 @@ from src.data.lang import LangAccessor
 # 优先商品模板标签 → 官方中文名。
 # 模板标签（weapon_quota/orobertyl）直接打进日志不可读，先映射为游戏内官方名称
 # （解包文本 assets/data/i18n_texts/*.json，key=e38d9b5bba114f81 / 8a3b3efb79c0131f）。
-# 日志/失败消息链路自带翻译机制，代码里勿手动 tr，否则整句 msgid 会与 ok.po 错位。
+# 带动态值的日志统一走 tr+format：外层静态模板先经 tr 查表（msgid=稳定模板串进 ok.po），
+# 内层已知静态文本值也过一层 tr，最后 .format 用已译值填充已译模板；
+# 禁止 f-string 整句拼接——填充后的整句作 msgid 无法命中 po 条目，外语 UI 下不翻译。
 _PRIORITY_ITEM_NAMES = {
     fL.weapon_quota.value: "武库配额",
     fL.orobertyl.value: "嵌晶玉",
@@ -53,7 +55,8 @@ class DailyShopFeature:
             if not self.back_shop():
                 self.log_info("信用商店刷新中断：未能返回采购页面")
                 return False, sum_credit
-            self.log_info(f"信用商店尝试刷新第{self.refresh_count + 1}次，预计消耗信用: {cost}，当前信用: {sum_credit}")
+            self.log_info(self.tr("信用商店尝试刷新第{count}次，预计消耗信用: {cost}，当前信用: {credit}").format(
+                count=self.refresh_count + 1, cost=cost, credit=sum_credit))
             shop_retry = 0
             while not self.wait_click_feature(
                     feature=fL.credit_shop_refresh, time_out=1,
@@ -76,7 +79,7 @@ class DailyShopFeature:
             temp_sum_credit = self.detect_ticket_number()
             if temp_sum_credit:
                 sum_credit = temp_sum_credit
-            self.log_info(f"信用商店刷新成功，消耗信用: {cost}，剩余信用: {sum_credit}")
+            self.log_info(self.tr("信用商店刷新成功，消耗信用: {cost}，剩余信用: {credit}").format(cost=cost, credit=sum_credit))
             return True, sum_credit
         return False, sum_credit
 
@@ -85,7 +88,7 @@ class DailyShopFeature:
             if self.wait_feature(feature=fL.credit_shop_icon, raise_if_not_found=False, time_out=1):
                 return True
             self.back()
-        self.info_set(self.CFG_CREDIT_SHOP_WARNING, f"返回采购页面失败，已重试{max_retry}次")
+        self.info_set(self.CFG_CREDIT_SHOP_WARNING, self.tr("返回采购页面失败，已重试{count}次").format(count=max_retry))
         return False
 
     def get_cost(self):
@@ -116,7 +119,8 @@ class DailyShopFeature:
         self.wait_ui_stable(refresh_interval=0.5)
         normal_results = []
         reserve_credit = self.config.get(self.CFG_KEEP_CREDIT, 300)
-        self.log_info(f"开始信用商店优先购买，当前信用: {sum_credit}，保留信用: {reserve_credit}")
+        self.log_info(self.tr("开始信用商店优先购买，当前信用: {credit}，保留信用: {reserve}").format(
+            credit=sum_credit, reserve=reserve_credit))
         if not self.back_shop():
             return False, sum_credit, False
 
@@ -140,7 +144,8 @@ class DailyShopFeature:
             filtered_discounts = []
             for discount in discount_results:
                 if any(self._discount_near_priority(discount, priority) for priority in normal_results):
-                    self.log_info(f"丢弃与优先商品邻近的折扣框: {discount.name}")
+                    # 折扣框文本是运行时 OCR 结果，仅外层模板过 tr，值不进收集池
+                    self.log_info(self.tr("丢弃与优先商品邻近的折扣框: {name}").format(name=discount.name))
                     continue
                 filtered_discounts.append(discount)
             discount_results = filtered_discounts
@@ -150,11 +155,16 @@ class DailyShopFeature:
         candidates.extend((item, True) for item in (discount_results or []))
         for idx, (item, is_discount_item) in enumerate(candidates, start=1):
             # 模板标签（weapon_quota/orobertyl）替换为官方中文名，保证日志可读；
-            # 不手动调 self.tr——log_info/mark_task_failure 链路自带翻译机制，
-            # 预翻译会使整句 msgid 与 ok.po 条目错位。
+            # 已知官方名是静态值，可安全过 tr 查表翻译（内层值翻译）；
+            # 运行时未知名称不过 tr，避免污染 i18n 收集池。
             raw_name = getattr(item, "name", None)
-            item_name = _PRIORITY_ITEM_NAMES.get(raw_name, raw_name) or f"未知商品#{idx}"
-            self.log_info(f"尝试购买优先商品: {item_name}，当前信用: {sum_credit}")
+            known_name = _PRIORITY_ITEM_NAMES.get(raw_name or "")
+            if known_name:
+                item_name = self.tr(known_name)
+            else:
+                item_name = raw_name or self.tr("未知商品#{idx}").format(idx=idx)
+            self.log_info(self.tr("尝试购买优先商品: {name}，当前信用: {credit}").format(
+                name=item_name, credit=sum_credit))
             if not self.back_shop():
                 self.info_set(self.CFG_CREDIT_SHOP_WARNING, "购买优先商品前未能返回采购页面")
                 return False, sum_credit, False
@@ -163,31 +173,34 @@ class DailyShopFeature:
             cost = self.get_cost()
             if cost <= 0:
                 if is_discount_item:
-                    self.log_info(f"商品: {item_name}，未识别到有效价格，折扣商品设置价格为10.000")
+                    self.log_info(self.tr("商品: {name}，未识别到有效价格，折扣商品设置价格为10.000").format(name=item_name))
                     cost = 10
                 else:
                     self.info_set(self.CFG_CREDIT_SHOP_WARNING, "购买优先商品前未能获取价格信息")
-                    self.mark_task_failure(f"购买失败: {item_name}，原因: 未识别到有效价格且非折扣商品")
+                    self.mark_task_failure(self.tr("购买失败: {name}，原因: 未识别到有效价格且非折扣商品").format(name=item_name))
                     return False, sum_credit, False
-            self.log_info(f"商品价格识别成功: {item_name}，价格: {cost}")
+            self.log_info(self.tr("商品价格识别成功: {name}，价格: {cost}").format(name=item_name, cost=cost))
             result = self.wait_click_feature(
                 feature=fL.skip_dialog_confirm, box=self.box_of_screen(0.816, 0.788, 0.855, 0.841), time_out=4, raise_if_not_found=False
             )
             if not result:
-                self.log_info(f"购买流程中断: {item_name}，未找到确认/不足弹窗，尝试返回采购页")
+                self.log_info(self.tr("购买流程中断: {name}，未找到确认/不足弹窗，尝试返回采购页").format(name=item_name))
                 if not self.back_shop():
                     return False, sum_credit, False
                 if cost != 10:
                     self.info_set(self.CFG_CREDIT_SHOP_WARNING, "购买优先商品时信用不足")
-                    self.mark_task_failure(f"购买失败: {item_name}，原因: 信用不足，当前信用: {sum_credit}，价格: {cost}")
+                    self.mark_task_failure(self.tr("购买失败: {name}，原因: 信用不足，当前信用: {credit}，价格: {cost}").format(
+                        name=item_name, credit=sum_credit, cost=cost))
                     self.back_shop()
                     return False, sum_credit, False
                 return False, sum_credit, True
             self.wait_pop_up()
             sum_credit -= cost
-            self.log_info(f"购买成功: {item_name}，消耗信用: {cost}，剩余信用: {sum_credit}")
+            self.log_info(self.tr("购买成功: {name}，消耗信用: {cost}，剩余信用: {credit}").format(
+                name=item_name, cost=cost, credit=sum_credit))
         if sum_credit <= reserve_credit:
-            self.log_info(f"信用降至保留阈值，停止优先购买，剩余信用: {sum_credit}，阈值: {reserve_credit}")
+            self.log_info(self.tr("信用降至保留阈值，停止优先购买，剩余信用: {credit}，阈值: {reserve}").format(
+                credit=sum_credit, reserve=reserve_credit))
             return True, sum_credit, True
         return False, sum_credit, True
 
@@ -214,13 +227,16 @@ class DailyShopFeature:
 
     def buy_left(self, sum_credit):
         reserve_credit = self.config.get(self.CFG_KEEP_CREDIT, 300)
-        self.log_info(f"开始购买剩余可购商品，当前信用: {sum_credit}，保留信用: {reserve_credit}")
+        self.log_info(self.tr("开始购买剩余可购商品，当前信用: {credit}，保留信用: {reserve}").format(
+            credit=sum_credit, reserve=reserve_credit))
         if not self.back_shop():
             return False
         results = self.find_feature(feature=fL.credit_can_buy, box=self.credit_good_search_box) or []
         for idx, item in enumerate(results, start=1):
-            item_name = getattr(item, "name", None) or f"未知商品#{idx}"
-            self.log_info(f"尝试购买剩余商品: {item_name}，当前信用: {sum_credit}")
+            # 剩余商品名是运行时匹配结果，不过 tr 防污染收集池；兜底名为静态模板可过 tr
+            item_name = getattr(item, "name", None) or self.tr("未知商品#{idx}").format(idx=idx)
+            self.log_info(self.tr("尝试购买剩余商品: {name}，当前信用: {credit}").format(
+                name=item_name, credit=sum_credit))
             if not self.back_shop():
                 self.info_set(self.CFG_CREDIT_SHOP_WARNING, "购买剩余商品前未能返回采购页面")
                 return False
@@ -228,20 +244,22 @@ class DailyShopFeature:
             self.wait_ui_stable(refresh_interval=0.5)
             cost = self.get_cost()
             if cost <= 0:
-                self.log_info(f"跳过商品: {item_name}，未识别到有效价格")
+                self.log_info(self.tr("跳过商品: {name}，未识别到有效价格").format(name=item_name))
                 continue
-            self.log_info(f"商品价格识别成功: {item_name}，价格: {cost}")
+            self.log_info(self.tr("商品价格识别成功: {name}，价格: {cost}").format(name=item_name, cost=cost))
             result = self.wait_click_feature(
                 feature=fL.skip_dialog_confirm, box=self.box_of_screen(0.816, 0.788, 0.855, 0.841), time_out=4, raise_if_not_found=False
             )
             if not result:
-                self.log_info(f"购买流程中断: {item_name}，未找到确认/不足弹窗，尝试返回采购页")
+                self.log_info(self.tr("购买流程中断: {name}，未找到确认/不足弹窗，尝试返回采购页").format(name=item_name))
                 self.back_shop()
                 return False
             self.wait_pop_up()
             sum_credit -= cost
-            self.log_info(f"购买成功: {item_name}，消耗信用: {cost}，剩余信用: {sum_credit}")
+            self.log_info(self.tr("购买成功: {name}，消耗信用: {cost}，剩余信用: {credit}").format(
+                name=item_name, cost=cost, credit=sum_credit))
             if sum_credit <= reserve_credit:
-                self.log_info(f"信用降至保留阈值，停止购买剩余商品，剩余信用: {sum_credit}，阈值: {reserve_credit}")
+                self.log_info(self.tr("信用降至保留阈值，停止购买剩余商品，剩余信用: {credit}，阈值: {reserve}").format(
+                    credit=sum_credit, reserve=reserve_credit))
                 return True
         return True

--- a/src/tasks/daily/daily_task_runner.py
+++ b/src/tasks/daily/daily_task_runner.py
@@ -69,7 +69,7 @@ class DailyTaskRunner:
         try:
             # 任务名/失败消息为运行时标识与文本，不过内层 tr
             self.task.log_info(self.task.tr("任务失败标记 | {name}: {message}").format(
-                name=resolved_task_name, message=resolved_message))
+                name=self.task.tr(resolved_task_name), message=resolved_message))
         except Exception:
             pass
 
@@ -143,14 +143,14 @@ class DailyTaskRunner:
             and input_mode() == "background"
             and key in getattr(self.task, "FOREGROUND_TASK_KEYS", ())
         ):
-            self.task.log_info(self.task.tr("后台模式下跳过需要前台操作的子任务: {key}").format(key=key))
+            self.task.log_info(self.task.tr("后台模式下跳过需要前台操作的子任务: {key}").format(key=self.task.tr(key)))
             self.task_status["skipped"].append(key)
             return True
 
         self.current_task_key = key
         self.failure_screenshot_tasks.discard(key)
         self.final_summary["current_task"] = key
-        self.task.log_info(self.task.tr("开始任务: {key}").format(key=key))
+        self.task.log_info(self.task.tr("开始任务: {key}").format(key=self.task.tr(key)))
         self.task.ensure_main()
         # shift 为奔跑切换键：后台模式下移动已禁用，无需切换奔跑状态
         if not (input_mode is not None and input_mode() == "background"):
@@ -162,7 +162,7 @@ class DailyTaskRunner:
             self.set_task_failure(self.task.tr("任务返回 False"), task_name=key)
             if key not in self.failure_screenshot_tasks:
                 self.task.screenshot(f'DailyTask_FailTask_{key}')
-            self.task.log_info(self.task.tr("任务 {key} 执行失败").format(key=key), notify=True)
+            self.task.log_info(self.task.tr("任务 {key} 执行失败").format(key=self.task.tr(key)), notify=True)
             return False
 
         self.task_status["success"].append(key)
@@ -204,7 +204,8 @@ class DailyTaskRunner:
 
                 if self.task_status["failed"]:
                     self.task.log_info(self.task.tr("第 {idx} 轮 | 失败任务: {failed}").format(
-                        idx=repeat_idx + 1, failed=self.task_status['failed']), notify=True)
+                        idx=repeat_idx + 1,
+                        failed=[self.task.tr(k) for k in self.task_status['failed']]), notify=True)
                 else:
                     self.task.log_info(self.task.tr("第 {idx} 轮 | 日常完成!").format(idx=repeat_idx + 1), notify=True)
 
@@ -218,7 +219,8 @@ class DailyTaskRunner:
             if self.final_summary["actual_repeat_total"] > 1:
                 if self.final_summary["all_fail_tasks"]:
                     self.task.log_info(self.task.tr("执行完成，失败统计: {failed}").format(
-                        failed=self.final_summary['all_fail_tasks']), notify=True)
+                        failed=[(idx, [self.task.tr(k) for k in keys])
+                                for idx, keys in self.final_summary['all_fail_tasks']]), notify=True)
                 else:
                     self.task.log_info("所有任务均成功完成!", notify=True)
 
@@ -249,7 +251,7 @@ class DailyTaskRunner:
             current_message = self.failure_details.get(self.current_task_key, "")
             if current_message:
                 self.task.info_set("当前失败的任务", self.task.tr("{key}: {message}").format(
-                    key=self.current_task_key, message=current_message))
+                    key=self.task.tr(self.current_task_key), message=current_message))
             else:
                 self.task.info_set("当前失败的任务", self.current_task_key)
 

--- a/src/tasks/daily/daily_task_runner.py
+++ b/src/tasks/daily/daily_task_runner.py
@@ -67,7 +67,9 @@ class DailyTaskRunner:
             self.failure_details[account_id] = {}
         self.failure_details[account_id].setdefault(resolved_task_name, resolved_message)
         try:
-            self.task.log_info(f"任务失败标记 | {resolved_task_name}: {resolved_message}")
+            # 任务名/失败消息为运行时标识与文本，不过内层 tr
+            self.task.log_info(self.tr("任务失败标记 | {name}: {message}").format(
+                name=resolved_task_name, message=resolved_message))
         except Exception:
             pass
 
@@ -141,14 +143,14 @@ class DailyTaskRunner:
             and input_mode() == "background"
             and key in getattr(self.task, "FOREGROUND_TASK_KEYS", ())
         ):
-            self.task.log_info(f"后台模式下跳过需要前台操作的子任务: {key}")
+            self.task.log_info(self.tr("后台模式下跳过需要前台操作的子任务: {key}").format(key=key))
             self.task_status["skipped"].append(key)
             return True
 
         self.current_task_key = key
         self.failure_screenshot_tasks.discard(key)
         self.final_summary["current_task"] = key
-        self.task.log_info(f"开始任务: {key}")
+        self.task.log_info(self.tr("开始任务: {key}").format(key=key))
         self.task.ensure_main()
         # shift 为奔跑切换键：后台模式下移动已禁用，无需切换奔跑状态
         if not (input_mode is not None and input_mode() == "background"):
@@ -157,10 +159,10 @@ class DailyTaskRunner:
 
         if result is False:
             self.task_status["failed"].append(key)
-            self.set_task_failure("任务返回 False", task_name=key)
+            self.set_task_failure(self.tr("任务返回 False"), task_name=key)
             if key not in self.failure_screenshot_tasks:
                 self.task.screenshot(f'DailyTask_FailTask_{key}')
-            self.task.log_info(f"任务 {key} 执行失败", notify=True)
+            self.task.log_info(self.tr("任务 {key} 执行失败").format(key=key), notify=True)
             return False
 
         self.task_status["success"].append(key)
@@ -184,14 +186,16 @@ class DailyTaskRunner:
             ):
                 self._mark_round_context(repeat_idx + 1, repeat_total)
                 if not self.task.config.get("多账户模式", False) and self.task.debug:
-                    self.task.log_info(f"调试模式，第 {repeat_idx + 1}/{repeat_total} 轮")
+                    self.task.log_info(self.tr("调试模式，第 {idx}/{total} 轮").format(
+                        idx=repeat_idx + 1, total=repeat_total))
 
                 if not self.task._logged_in:
                     self.task.ensure_main(time_out=600)
                 else:
                     self.task.ensure_main()
                 self._reset_shared_task_state()
-                self.task.log_info(f"开始第 {repeat_idx + 1}/{repeat_total} 轮任务执行")
+                self.task.log_info(self.tr("开始第 {idx}/{total} 轮任务执行").format(
+                    idx=repeat_idx + 1, total=repeat_total))
 
                 for item in self.task_items:
                     key, func = item[0], item[1]
@@ -199,9 +203,10 @@ class DailyTaskRunner:
                     self.execute_task(key, func, predicate)
 
                 if self.task_status["failed"]:
-                    self.task.log_info(f"第 {repeat_idx + 1} 轮 | 失败任务: {self.task_status['failed']}", notify=True)
+                    self.task.log_info(self.tr("第 {idx} 轮 | 失败任务: {failed}").format(
+                        idx=repeat_idx + 1, failed=self.task_status['failed']), notify=True)
                 else:
-                    self.task.log_info(f"第 {repeat_idx + 1} 轮 | 日常完成!", notify=True)
+                    self.task.log_info(self.tr("第 {idx} 轮 | 日常完成!").format(idx=repeat_idx + 1), notify=True)
 
                 self._append_round_summary(repeat_idx + 1, repeat_total)
                 self._sync_task_status_info()
@@ -212,7 +217,8 @@ class DailyTaskRunner:
                 self.final_summary["status"] = "完成"
             if self.final_summary["actual_repeat_total"] > 1:
                 if self.final_summary["all_fail_tasks"]:
-                    self.task.log_info(f"执行完成，失败统计: {self.final_summary['all_fail_tasks']}", notify=True)
+                    self.task.log_info(self.tr("执行完成，失败统计: {failed}").format(
+                        failed=self.final_summary['all_fail_tasks']), notify=True)
                 else:
                     self.task.log_info("所有任务均成功完成!", notify=True)
 
@@ -228,7 +234,7 @@ class DailyTaskRunner:
         self.final_summary["exception"] = str(e)
         self.final_summary["current_task"] = self.current_task_key or self.final_summary.get("current_task", "")
         if self.current_task_key:
-            self.set_task_failure(f"异常: {e}", task_name=self.current_task_key)
+            self.set_task_failure(self.tr("异常: {err}").format(err=e), task_name=self.current_task_key)
         if self._current_round_index is not None:
             already_captured = any(
                 round_item.get("round") == self._current_round_index
@@ -242,7 +248,8 @@ class DailyTaskRunner:
         if self.current_task_key:
             current_message = self.failure_details.get(self.current_task_key, "")
             if current_message:
-                self.task.info_set("当前失败的任务", f"{self.current_task_key}: {current_message}")
+                self.task.info_set("当前失败的任务", self.tr("{key}: {message}").format(
+                    key=self.current_task_key, message=current_message))
             else:
                 self.task.info_set("当前失败的任务", self.current_task_key)
 

--- a/src/tasks/daily/daily_task_runner.py
+++ b/src/tasks/daily/daily_task_runner.py
@@ -68,7 +68,7 @@ class DailyTaskRunner:
         self.failure_details[account_id].setdefault(resolved_task_name, resolved_message)
         try:
             # 任务名/失败消息为运行时标识与文本，不过内层 tr
-            self.task.log_info(self.tr("任务失败标记 | {name}: {message}").format(
+            self.task.log_info(self.task.tr("任务失败标记 | {name}: {message}").format(
                 name=resolved_task_name, message=resolved_message))
         except Exception:
             pass
@@ -143,14 +143,14 @@ class DailyTaskRunner:
             and input_mode() == "background"
             and key in getattr(self.task, "FOREGROUND_TASK_KEYS", ())
         ):
-            self.task.log_info(self.tr("后台模式下跳过需要前台操作的子任务: {key}").format(key=key))
+            self.task.log_info(self.task.tr("后台模式下跳过需要前台操作的子任务: {key}").format(key=key))
             self.task_status["skipped"].append(key)
             return True
 
         self.current_task_key = key
         self.failure_screenshot_tasks.discard(key)
         self.final_summary["current_task"] = key
-        self.task.log_info(self.tr("开始任务: {key}").format(key=key))
+        self.task.log_info(self.task.tr("开始任务: {key}").format(key=key))
         self.task.ensure_main()
         # shift 为奔跑切换键：后台模式下移动已禁用，无需切换奔跑状态
         if not (input_mode is not None and input_mode() == "background"):
@@ -159,10 +159,10 @@ class DailyTaskRunner:
 
         if result is False:
             self.task_status["failed"].append(key)
-            self.set_task_failure(self.tr("任务返回 False"), task_name=key)
+            self.set_task_failure(self.task.tr("任务返回 False"), task_name=key)
             if key not in self.failure_screenshot_tasks:
                 self.task.screenshot(f'DailyTask_FailTask_{key}')
-            self.task.log_info(self.tr("任务 {key} 执行失败").format(key=key), notify=True)
+            self.task.log_info(self.task.tr("任务 {key} 执行失败").format(key=key), notify=True)
             return False
 
         self.task_status["success"].append(key)
@@ -182,11 +182,11 @@ class DailyTaskRunner:
             for repeat_idx, repeat_total in self.task.iter_multi_account_context(
                     repeat_times=repeat_times,
                     empty_accounts_message="多账户模式已开启，但账号列表为空，日常任务结束",
-                    account_log_suffix="任务执行",
+                    account_log_suffix=self.task.tr("任务执行"),
             ):
                 self._mark_round_context(repeat_idx + 1, repeat_total)
                 if not self.task.config.get("多账户模式", False) and self.task.debug:
-                    self.task.log_info(self.tr("调试模式，第 {idx}/{total} 轮").format(
+                    self.task.log_info(self.task.tr("调试模式，第 {idx}/{total} 轮").format(
                         idx=repeat_idx + 1, total=repeat_total))
 
                 if not self.task._logged_in:
@@ -194,7 +194,7 @@ class DailyTaskRunner:
                 else:
                     self.task.ensure_main()
                 self._reset_shared_task_state()
-                self.task.log_info(self.tr("开始第 {idx}/{total} 轮任务执行").format(
+                self.task.log_info(self.task.tr("开始第 {idx}/{total} 轮任务执行").format(
                     idx=repeat_idx + 1, total=repeat_total))
 
                 for item in self.task_items:
@@ -203,10 +203,10 @@ class DailyTaskRunner:
                     self.execute_task(key, func, predicate)
 
                 if self.task_status["failed"]:
-                    self.task.log_info(self.tr("第 {idx} 轮 | 失败任务: {failed}").format(
+                    self.task.log_info(self.task.tr("第 {idx} 轮 | 失败任务: {failed}").format(
                         idx=repeat_idx + 1, failed=self.task_status['failed']), notify=True)
                 else:
-                    self.task.log_info(self.tr("第 {idx} 轮 | 日常完成!").format(idx=repeat_idx + 1), notify=True)
+                    self.task.log_info(self.task.tr("第 {idx} 轮 | 日常完成!").format(idx=repeat_idx + 1), notify=True)
 
                 self._append_round_summary(repeat_idx + 1, repeat_total)
                 self._sync_task_status_info()
@@ -217,7 +217,7 @@ class DailyTaskRunner:
                 self.final_summary["status"] = "完成"
             if self.final_summary["actual_repeat_total"] > 1:
                 if self.final_summary["all_fail_tasks"]:
-                    self.task.log_info(self.tr("执行完成，失败统计: {failed}").format(
+                    self.task.log_info(self.task.tr("执行完成，失败统计: {failed}").format(
                         failed=self.final_summary['all_fail_tasks']), notify=True)
                 else:
                     self.task.log_info("所有任务均成功完成!", notify=True)
@@ -234,7 +234,7 @@ class DailyTaskRunner:
         self.final_summary["exception"] = str(e)
         self.final_summary["current_task"] = self.current_task_key or self.final_summary.get("current_task", "")
         if self.current_task_key:
-            self.set_task_failure(self.tr("异常: {err}").format(err=e), task_name=self.current_task_key)
+            self.set_task_failure(self.task.tr("异常: {err}").format(err=e), task_name=self.current_task_key)
         if self._current_round_index is not None:
             already_captured = any(
                 round_item.get("round") == self._current_round_index
@@ -248,7 +248,7 @@ class DailyTaskRunner:
         if self.current_task_key:
             current_message = self.failure_details.get(self.current_task_key, "")
             if current_message:
-                self.task.info_set("当前失败的任务", self.tr("{key}: {message}").format(
+                self.task.info_set("当前失败的任务", self.task.tr("{key}: {message}").format(
                     key=self.current_task_key, message=current_message))
             else:
                 self.task.info_set("当前失败的任务", self.current_task_key)

--- a/src/tasks/daily/daily_trade_mixin.py
+++ b/src/tasks/daily/daily_trade_mixin.py
@@ -117,7 +117,7 @@ class DailyTradeFeature:
 
             min_item = min(candidates, key=lambda x: x.good_price)
 
-            self.log_info(f"最低价格: {min_item.good_price}")
+            self.log_info(self.tr("最低价格: {price}").format(price=min_item.good_price))
 
             return min_item, market_text_y
 
@@ -304,12 +304,12 @@ class DailyTradeFeature:
         navigation_failed = False
         for area in target_areas or areas_list:
             if not self.config.get(area, False):
-                self.log_info(f"跳过{area}，因为配置中未启用")
+                self.log_info(self.tr("跳过{area}，因为配置中未启用").format(area=self.tr(area)))
                 continue
             if not keep_area_context:
                 self.ensure_main()
             if not self.to_model_area(area, "物资调度"):
-                self.log_info(f"无法进入{area}物资调度，买卖货失败")
+                self.log_info(self.tr("无法进入{area}物资调度，买卖货失败").format(area=self.tr(area)))
                 navigation_failed = True
                 continue
             self.wait_click_ocr(
@@ -402,7 +402,8 @@ class DailyTradeFeature:
 
             for sell_good in sell_goods:
                 if sell_good.stock_quantity <= 0:
-                    self.log_info(f"跳过出售 {sell_good.good_name}，存货数量<=0")
+                    # 物品名来自游戏数据运行时加载不过 tr
+                    self.log_info(self.tr("跳过出售 {name}，存货数量<=0").format(name=sell_good.good_name))
                     continue
                 back_to_area_deadline = self.active_time() + 20
                 while not self.wait_ocr(

--- a/src/tasks/daily/misc/daily_boat_mixin.py
+++ b/src/tasks/daily/misc/daily_boat_mixin.py
@@ -180,7 +180,7 @@ class DailyBoatMixin:
             char_list = list(get_contact_list_with_feature_list().values())
             count = 0
             for char in char_list:
-                if result := self.find_one(feature=char, box=self.box_of_screen(0.3, 0, 1, 1)):
+                if result := self.find_one(char, box=self.box_of_screen(0.3, 0, 1, 1)):
                     self.click(result)
                     count += 1
                 if count >= 2:

--- a/src/tasks/daily/misc/daily_logistics_mixin.py
+++ b/src/tasks/daily/misc/daily_logistics_mixin.py
@@ -18,7 +18,7 @@ class DailyLogisticsMixin:
         start_time = self.active_time()
         while True:
             if self.active_time() - start_time > time_out:
-                self.log_info(f"盲点加速超时，未找到 {feature}")
+                self.log_info(self.tr("盲点加速超时，未找到 {feature}").format(feature=feature))
                 return False
             if self.find_feature(feature=feature, box=box):
                 return True
@@ -101,13 +101,12 @@ class DailyLogisticsMixin:
         for area in areas_list:
             activity_num = 0
             count = 0
-            self.log_info(f"开始处理区域: {area}")
+            self.log_info(self.tr("开始处理区域: {area}").format(area=self.tr(area)))
 
             while True:
                 if 0 < activity_num <= count:
-                    self.log_info(
-                        f"{area}仓储节点已完成{activity_num}次，停止继续"
-                    )
+                    self.log_info(self.tr("{area}仓储节点已完成{count}次，停止继续").format(
+                        area=self.tr(area), count=activity_num))
                     break
 
                 self.to_model_area(area, "仓储节点")
@@ -122,7 +121,7 @@ class DailyLogisticsMixin:
                         box=self.box.top_left,
                         time_out=5
                 ):
-                    self.log_info(f"{area}未找到本地仓储节点，返回主界面")
+                    self.log_info(self.tr("{area}未找到本地仓储节点，返回主界面").format(area=self.tr(area)))
                     self.ensure_main()
                     break
 
@@ -134,7 +133,7 @@ class DailyLogisticsMixin:
 
                 if not results:
                     self.log_info(
-                        f"{area} 当前没有货物装箱可操作，返回主界面"
+                        self.tr("{area} 当前没有货物装箱可操作，返回主界面").format(area=self.tr(area))
                     )
                     self.ensure_main()
                     break
@@ -142,7 +141,8 @@ class DailyLogisticsMixin:
                 if activity_num == 0:
                     activity_num = len(results)
                     self.log_info(
-                        f"{area}共有{activity_num}次可进行转交运送委托的活动",
+                        self.tr("{area}共有{activity_num}次可进行转交运送委托的活动").format(
+                            area=self.tr(area), activity_num=activity_num),
                         notify=True,
                     )
 
@@ -180,7 +180,7 @@ class DailyLogisticsMixin:
                             continue
 
                         self.log_info(
-                            f"步骤 {feature} 未找到，跳过本次活动"
+                            self.tr("步骤 {feature} 未找到，跳过本次活动").format(feature=feature)
                         )
                         break
                 self.ensure_main()

--- a/src/tasks/daily/misc/daily_reward_mixin.py
+++ b/src/tasks/daily/misc/daily_reward_mixin.py
@@ -11,10 +11,11 @@ class DailyRewardMixin:
                 time_out=time_out,
                 after_sleep=after_sleep,
         ):
-            self.mark_task_failure(f"未找到{match_str}按钮，任务失败")
+            # match_str 是调用方传入的 OCR 匹配文本（运行时参数）不过 tr
+            self.mark_task_failure(self.tr("未找到{name}按钮，任务失败").format(name=match_str))
             return False
 
-        self.log_info(f"找到{match_str}按钮并点击")
+        self.log_info(self.tr("找到{name}按钮并点击").format(name=match_str))
         return True
 
     def claim_weekly_rewards(self):

--- a/src/tasks/mixin/liaison_mixin.py
+++ b/src/tasks/mixin/liaison_mixin.py
@@ -539,7 +539,7 @@ class LiaisonMixin(NavigationMixin):
         """
         self.log_info("开始收取或赠送礼物")
         start_time = self.active_time()
-        while self.find_one(feature=fL.esc, vertical_variance=0.01, horizontal_variance=0.02):
+        while self.find_one(fL.esc, vertical_variance=0.01, horizontal_variance=0.02):
             if self.active_time() - start_time > 5:
                 self.log_info("没能进入交流界面")
                 return False

--- a/src/tasks/mixin/navigation_mixin.py
+++ b/src/tasks/mixin/navigation_mixin.py
@@ -470,7 +470,8 @@ class NavigationMixin(SearchMixin):
                     result.x + result.width // 2,
                     result.y + result.height // 2,
                 )
-                screen_center_pos = self.screen_center()
+                # 屏幕中心（原 RuntimeMixin.screen_center 已移除，直接内联计算）
+                screen_center_pos = (int(self.width / 2), int(self.height / 2))
                 last_target = result
                 last_target_fail_count = 0
                 # 计算偏移量
@@ -502,7 +503,7 @@ class NavigationMixin(SearchMixin):
                     decay = 0.9 ** last_target_fail_count
                     # 计算目标中心到屏幕中心的偏移
 
-                    screen_center_x, screen_center_y = self.screen_center()
+                    screen_center_x, screen_center_y = int(self.width / 2), int(self.height / 2)
                     offset_x = int((screen_center_x - last_target.x) * decay)
                     offset_y = int((screen_center_y - last_target.y) * decay)
                     offset_width = int(last_target.width / 2 * decay)

--- a/src/tasks/onetime/DeliveryTask.py
+++ b/src/tasks/onetime/DeliveryTask.py
@@ -885,7 +885,7 @@ class DeliveryTask(AccountMixin, ZipLineMixin, MapMixin):
             for repeat_idx, repeat_times in self.iter_multi_account_context(
                     repeat_times=1,
                     empty_accounts_message="多账户模式已开启，但账号列表为空，自动送货任务结束",
-                    account_log_suffix="自动送货",
+                    account_log_suffix=self.tr("自动送货"),
                     allow_multi_account=allow_multi,
             ):
                 self._run_single_delivery_cycle()

--- a/src/tasks/onetime/WarehouseTransferTask.py
+++ b/src/tasks/onetime/WarehouseTransferTask.py
@@ -178,7 +178,7 @@ class WarehouseTransferTask(BaseEfTask):
             if not item_key_en:
                 self.log_info(f"找不到的图标名 {item_key}")
             for round_idx in range(ROUND + 1):
-                icon = self.find_one(feature=item_key_en, box=search_box, threshold=0.8)
+                icon = self.find_one(item_key_en, box=search_box, threshold=0.8)
                 if icon:
                     break
                 if round_idx == ROUND:

--- a/src/tasks/trigger/AutoInteractionTask.py
+++ b/src/tasks/trigger/AutoInteractionTask.py
@@ -44,9 +44,9 @@ class AutoInteractionTask(BaseEfTask, TriggerTask):
                     return
         if self.config.get('自动点击传送', True):
             # 先普通匹配；未找到时再尝试一次轮廓（Canny）匹配，对按钮反色/主题变化不敏感
-            result = self.find_one(feature=fL.transfer_go, frame=now)
+            result = self.find_one(fL.transfer_go, frame=now)
             if not result:
-                result = self.find_one(feature=fL.transfer_go, frame=now, canny_lower=50, canny_higher=150, threshold=0.8)
+                result = self.find_one(fL.transfer_go, frame=now, canny_lower=50, canny_higher=150, threshold=0.8)
             if result:
-                if self.find_one(feature=fL.in_map,box=self.box_of_screen(0.027, 0.531, 0.051, 0.896) , frame=now):
+                if self.find_one(fL.in_map, box=self.box_of_screen(0.027, 0.531, 0.051, 0.896), frame=now):
                     self.click(result, after_sleep=0.4)

--- a/src/tasks/trigger/ItemNavigatorTask.py
+++ b/src/tasks/trigger/ItemNavigatorTask.py
@@ -313,7 +313,9 @@ class ItemNavigatorTask(WsPositionMixin, BaseEfTask, TriggerTask):
             # 如果新路径不存在，检查旧路径并迁移
             old_path = Path('assets') / 'items' / 'map' / 'marked_points.json'
             if old_path.exists():
-                self.log_info(f"发现旧路径的 marked_points.json，正在迁移到新路径: {self._marked_store}")
+                # 存储路径是运行时值不过 tr
+                self.log_info(self.tr("发现旧路径的 marked_points.json，正在迁移到新路径: {path}").format(
+                    path=self._marked_store))
                 try:
                     data = json.loads(old_path.read_text(encoding='utf-8'))
                     for k, v in (data or {}).items():
@@ -391,7 +393,7 @@ class ItemNavigatorTask(WsPositionMixin, BaseEfTask, TriggerTask):
             )
 
             if not success:
-                self.log_info(f"[箭头] 绘制失败")
+                self.log_info("[箭头] 绘制失败")
                 return
 
             if tooltip:

--- a/tests/TestDailyBoatState.py
+++ b/tests/TestDailyBoatState.py
@@ -20,6 +20,9 @@ class _RunnerHarness:
     def log_info(self, *args, **kwargs):
         pass
 
+    def tr(self, message, **kwargs):
+        return message
+
     def screenshot(self, *args, **kwargs):
         pass
 

--- a/tests/TestDailyRegionalRunner.py
+++ b/tests/TestDailyRegionalRunner.py
@@ -20,6 +20,7 @@ def _make_task(config_options, buy_sell_result=True, after_buy_called=True,
     task.to_model_area = Mock(return_value=to_model_area_result)
     task.safe_back = Mock()
     task.log_info = Mock()
+    task.tr = lambda message, **kwargs: message
 
     def buy_sell_impl(target_areas=None, keep_area_context=False, after_buy=None):
         if after_buy is not None and after_buy_called and target_areas:

--- a/tests/TestDeliveryRewardsClaim.py
+++ b/tests/TestDeliveryRewardsClaim.py
@@ -57,6 +57,7 @@ class TestDeliverySendOthersClaimRetry(unittest.TestCase):
         feature = object.__new__(DailyLogisticsMixin)
         feature.info_set = Mock()
         feature.log_info = Mock()
+        feature.tr = lambda message, **kwargs: message
         feature.mark_task_failure = Mock()
         feature.to_model_area = Mock(return_value=True)
         feature.ensure_main = Mock()

--- a/tests/TestStateDrivenWaits.py
+++ b/tests/TestStateDrivenWaits.py
@@ -15,6 +15,9 @@ class _EnsureMainHarness(GameFlowMixin):
         self.esc_checks = []
         self.sleeps = []
 
+    def tr(self, message, **kwargs):
+        return message
+
     def check_resolution(self):
         pass
 

--- a/tests/TestYoloDetect.py
+++ b/tests/TestYoloDetect.py
@@ -19,6 +19,9 @@ class _DummyTask(RuntimeMixin):
     def log_info(self, message):
         self.logs.append(message)
 
+    def tr(self, message, **kwargs):
+        return message
+
     def next_frame(self):
         return np.zeros((500, 500, 3), dtype=np.uint8)
 


### PR DESCRIPTION
## 改动总结

### 1. 动态值日志统一 tr+format（i18n 规范化）

按 AGENTS.md 更新后的第 5 条规则执行：带动态值的日志统一在调用侧走 `self.tr("模板{a}").format(a=...)`——外层静态模板过 tr（msgid=稳定模板串进 po），文本类动态值内层过 tr 后填充，纯数字值直接填充，运行时未知文本（OCR 结果、账号名、异常消息等）不过 tr 防污染收集池。

涉及：`BaseEfTask`（多账号循环日志）、`game_flow_mixin`（ensure_main info_set 模板）、`process_manager`（终止进程日志）、`runtime_mixin`（safe_back 超时 / yolo_detect / wait ocr no box）、`account_mixin`、daily 各 mixin（buy/credit/demo/liaison/regional_runner/shop/task_runner/trade/logistics/reward/boat）、`ItemNavigatorTask`。

### 2. runtime_mixin 清理冗余封装（净 -90 行）

删除与框架 `ok.task.BaseTask` 完全重复的透传方法：

- `screen_center()` — 仅 navigation_mixin 两处调用，已内联为 `(int(self.width / 2), int(self.height / 2))`
- `find_one()`（feature 别名兼容封装）— 框架签名无 feature 关键字，7 处 `find_one(feature=x, ...)` 调用点改为位置参数（AutoInteractionTask ×3、liaison_mixin、WarehouseTransferTask、daily_boat_mixin、daily_demo_mixin）
- `send_key()` 透传 — 调用点改用框架默认 `down_time=0.02`（与 press_key 默认一致）

### 3. AGENTS.md

更新「i18n 收集池防污染」第 5 条：由「仅通知链路走 tr+format」改为「带动态值的日志统一在调用侧走 tr+format」，并写明内层值翻译与防污染边界。

## 备注

- 新增 msgid 待 debug 模式收集后经「开发工具→生成 i18n 文件」统一导出编译 po。
- 已通过 py_compile 全量语法检查；find_one/send_key 签名已对照 .venv 内 ok 框架源码逐一核实。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **本地化**
  - 统一任务、账号、导航、交易、通知及流程日志的翻译处理。
  - 动态内容按类型格式化，避免运行时未知文本进入翻译收集范围。
  - 商品、区域、任务及操作名称等已知文本支持更一致的本地化显示。

- **改进**
  - 优化部分识别、导航和窗口中心计算流程，提升运行稳定性。
  - 保持原有任务执行、失败处理与交互流程不变。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->