### PR TITLE
fix: 屏蔽qfluentwidgets的推销信息

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,9 +1,12 @@
 from src.patches.pre_config_patch import install_pre_config_patch
+from src.patches.qfluent_mute_promo_patch import install_mute_promo_patch
 
 install_pre_config_patch()
+install_mute_promo_patch()
 
 from src.config import config  # noqa: E402
 from src.patches.startup_patches import install_startup_patches  # noqa: E402
+
 
 if __name__ == "__main__":
     config = config

--- a/main_debug.py
+++ b/main_debug.py
@@ -1,9 +1,12 @@
 from src.patches.pre_config_patch import install_pre_config_patch
+from src.patches.qfluent_mute_promo_patch import install_mute_promo_patch
 
 install_pre_config_patch()
+install_mute_promo_patch()
 
 from src.config import config  # noqa: E402
 from src.patches.startup_patches import install_startup_patches  # noqa: E402
+
 
 if __name__ == "__main__":
     config = config

--- a/src/patches/qfluent_mute_promo_patch.py
+++ b/src/patches/qfluent_mute_promo_patch.py
@@ -1,0 +1,42 @@
+"""Suppress the qfluentwidgets promo banner printed at first import."""
+
+import sys
+from contextlib import ContextDecorator
+
+
+class _BlackHoleStream:
+    """A fake stream that discards all writes to the real *stream*."""
+
+    def __init__(self, stream):
+        self._stream = stream
+
+    def write(self, text):
+        return len(text)
+
+    def flush(self):
+        self._stream.flush()
+
+    def isatty(self):
+        return self._stream.isatty()
+
+
+class muted_stdout(ContextDecorator):
+    """Temporarily route ``sys.stdout`` writes into a black hole."""
+
+    def __enter__(self):
+        self._original = sys.stdout
+        sys.stdout = _BlackHoleStream(self._original)
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        sys.stdout = self._original
+        return False
+
+
+def install_mute_promo_patch():
+    """This function will dry-import qfluentwidgets to suppress
+    the promo banner printed at first import.
+    """
+
+    with muted_stdout():
+        import qfluentwidgets  # noqa: F401


### PR DESCRIPTION
## 概要

此 PR 通过简单无害的方式，避免了导入 qfluentwidgets 时会打印以下推销信息到控制台：

```
\n\x1b[1;33m📢 Tips:\x1b[0m QFluentWidgets Pro is now released. Click \x1b[1;96mhttps://qfluentwidgets.com/pages/pro\x1b[0m to learn more about it.\n\n
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **体验改进**
  * 优化应用启动体验：首次加载相关组件时不再显示促销横幅或多余的控制台输出。
  * 启动过程保持安静，同时不影响应用正常运行。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->