### PR TITLE
docs: AGENTS.md 增加技能清单并新增 po 目录合并脚本

### DIFF
--- a/.agents/skills/ok-script-i18n/SKILL.md
+++ b/.agents/skills/ok-script-i18n/SKILL.md
@@ -39,6 +39,18 @@ Use `scripts/task_i18n_helper.py` in this skill (`.agents/skills/ok-script-i18n/
 
 The scanner is a helper, not a substitute for reading the task. It finds common literal strings but can miss values built through constants, imports, f-strings, comprehensions, or helper functions.
 
+### Merging conflicting catalogs (git merge / stash pop)
+
+When the same `ok.po` was modified on both sides (e.g. feature branch merged with `master` after a po sync commit like #252), the text `po` usually auto-merges but the binary `ok.mo` always conflicts. Resolve by merging the two po sides then recompiling — `scripts/merge_po.py` merges two po files by `msgid -> msgstr` dictionary, keeping entries unique to either side; when the same `msgid` exists on both sides with different translations, the **newer file (by mtime) wins** (override with `--prefer ours|theirs`). Recompile the merged po afterwards with `task_i18n_helper.py compile`.
+
+```powershell
+# 从合并状态取对方一侧：git show :3:path > theirs.po
+git show :3:i18n/zh_CN/LC_MESSAGES/ok.po > "$env:TEMP\theirs.po"
+.\.venv\Scripts\python.exe .agents\skills\ok-script-i18n\scripts\merge_po.py i18n\zh_CN\LC_MESSAGES\ok.po "$env:TEMP\theirs.po" --output i18n\zh_CN\LC_MESSAGES\ok.po --compile
+```
+
+After merging all locales, run `task_i18n_helper.py check` to confirm no duplicate `msgid` remains.
+
 ## Catalog Rules
 
 - Keep `msgid` exactly equal to the source string used by the code.

--- a/.agents/skills/ok-script-i18n/SKILL.md
+++ b/.agents/skills/ok-script-i18n/SKILL.md
@@ -45,8 +45,9 @@ When the same `ok.po` was modified on both sides (e.g. feature branch merged wit
 
 ```powershell
 # 从合并状态取双方两侧：git show :2:path (ours), git show :3:path (theirs)
-git show :2:i18n/zh_CN/LC_MESSAGES/ok.po > "$env:TEMP\ours.po"
-git show :3:i18n/zh_CN/LC_MESSAGES/ok.po > "$env:TEMP\theirs.po"
+# 注意：必须显式 UTF-8 导出（PowerShell 5.1 的 > 重定向会写 UTF-16LE，polib 按 UTF-8 解码会失败）
+git show :2:i18n/zh_CN/LC_MESSAGES/ok.po | Out-File -Encoding utf8 "$env:TEMP\ours.po"
+git show :3:i18n/zh_CN/LC_MESSAGES/ok.po | Out-File -Encoding utf8 "$env:TEMP\theirs.po"
 .\.venv\Scripts\python.exe .agents\skills\ok-script-i18n\scripts\merge_po.py "$env:TEMP\ours.po" "$env:TEMP\theirs.po" --output i18n\zh_CN\LC_MESSAGES\ok.po --prefer ours --compile
 ```
 

--- a/.agents/skills/ok-script-i18n/SKILL.md
+++ b/.agents/skills/ok-script-i18n/SKILL.md
@@ -44,9 +44,10 @@ The scanner is a helper, not a substitute for reading the task. It finds common 
 When the same `ok.po` was modified on both sides (e.g. feature branch merged with `master` after a po sync commit like #252), the text `po` usually auto-merges but the binary `ok.mo` always conflicts. Resolve by merging the two po sides then recompiling — `scripts/merge_po.py` merges two po files by `msgid -> msgstr` dictionary, keeping entries unique to either side; when the same `msgid` exists on both sides with different translations, the **newer file (by mtime) wins** (override with `--prefer ours|theirs`). Recompile the merged po afterwards with `task_i18n_helper.py compile`.
 
 ```powershell
-# 从合并状态取对方一侧：git show :3:path > theirs.po
+# 从合并状态取双方两侧：git show :2:path (ours), git show :3:path (theirs)
+git show :2:i18n/zh_CN/LC_MESSAGES/ok.po > "$env:TEMP\ours.po"
 git show :3:i18n/zh_CN/LC_MESSAGES/ok.po > "$env:TEMP\theirs.po"
-.\.venv\Scripts\python.exe .agents\skills\ok-script-i18n\scripts\merge_po.py i18n\zh_CN\LC_MESSAGES\ok.po "$env:TEMP\theirs.po" --output i18n\zh_CN\LC_MESSAGES\ok.po --compile
+.\.venv\Scripts\python.exe .agents\skills\ok-script-i18n\scripts\merge_po.py "$env:TEMP\ours.po" "$env:TEMP\theirs.po" --output i18n\zh_CN\LC_MESSAGES\ok.po --prefer ours --compile
 ```
 
 After merging all locales, run `task_i18n_helper.py check` to confirm no duplicate `msgid` remains.

--- a/.agents/skills/ok-script-i18n/scripts/merge_po.py
+++ b/.agents/skills/ok-script-i18n/scripts/merge_po.py
@@ -1,0 +1,108 @@
+"""po 目录合并工具：按 msgid->msgstr 字典合并两个 po 文件。
+
+用途：git merge / stash pop 等场景下同一 ok.po 被双方修改时，以「较新者优先」
+的规则合并翻译目录，避免手工处理冲突：
+
+- 读取两方的 msgid -> POEntry 字典（跳过 header 条目）；
+- 同一 msgid 两边都有且内容不同：默认取 mtime 较新的文件一侧（可用
+  ``--prefer`` 显式指定）；
+- 只在某一侧存在的 msgid 全部保留；
+- 输出文件条目顺序：较新一侧原有顺序，较旧一侧独有条目追加在末尾；
+- 可选 ``--compile``：合并后立即把输出 po 编译为同目录 ok.mo。
+
+示例（合并冲突两侧的目录并重新编译）::
+
+    python merge_po.py ours.po theirs.po --output merged.po --compile
+"""
+import argparse
+import os
+import sys
+
+import polib
+
+
+def load_catalog(path):
+    po = polib.pofile(path)
+    header = None
+    entries = {}
+    for entry in po:
+        if not entry.msgid:
+            header = entry
+            continue
+        if entry.msgid not in entries:
+            entries[entry.msgid] = entry
+    return po, header, entries
+
+
+def merge_po(ours_path, theirs_path, prefer="newer"):
+    """合并两个 po 文件，返回 (输出 po, 采用规则说明列表)。"""
+    ours_po, ours_header, ours = load_catalog(ours_path)
+    theirs_po, theirs_header, theirs = load_catalog(theirs_path)
+
+    ours_mtime = os.path.getmtime(ours_path)
+    theirs_mtime = os.path.getmtime(theirs_path)
+    if prefer == "newer":
+        newer_first = ours_mtime >= theirs_mtime
+    elif prefer == "ours":
+        newer_first = True
+    elif prefer == "theirs":
+        newer_first = False
+    else:
+        raise ValueError("--prefer 仅支持 newer / ours / theirs")
+
+    first, second = (ours, theirs) if newer_first else (theirs, ours)
+    first_po = ours_po if newer_first else theirs_po
+    second_po = theirs_po if newer_first else ours_po
+    first_name = os.path.basename(ours_path) if newer_first else os.path.basename(theirs_path)
+    second_name = os.path.basename(theirs_path) if newer_first else os.path.basename(ours_path)
+
+    notes = []
+    merged = polib.POFile()
+    merged.metadata = dict(first_po.metadata or {})
+    header = ours_header if newer_first else theirs_header
+    if header is not None:
+        merged.insert(0, header)
+
+    used = set()
+    for msgid, entry in first.items():
+        if msgid in second:
+            other = second[msgid]
+            if other.msgstr != entry.msgstr or bool(other.flags) != bool(entry.flags):
+                notes.append(f"冲突取 {first_name}: {msgid!r}")
+        merged.append(entry)
+        used.add(msgid)
+    appended = 0
+    for msgid, entry in second.items():
+        if msgid in used:
+            continue
+        merged.append(entry)
+        appended += 1
+    if appended:
+        notes.append(f"追加 {second_name} 独有条目 {appended} 条")
+    return merged, notes
+
+
+def main():
+    parser = argparse.ArgumentParser(description="合并两个 po 目录文件，较新者优先")
+    parser.add_argument("ours", help="己方 po 文件路径")
+    parser.add_argument("theirs", help="对方 po 文件路径")
+    parser.add_argument("--output", required=True, help="合并结果输出路径")
+    parser.add_argument("--prefer", choices=("newer", "ours", "theirs"), default="newer",
+                        help="同一 msgid 冲突时的取舍（默认较新者，按文件 mtime）")
+    parser.add_argument("--compile", action="store_true",
+                        help="合并后编译输出 po 的同目录 ok.mo")
+    args = parser.parse_args()
+
+    merged, notes = merge_po(args.ours, args.theirs, prefer=args.prefer)
+    for note in notes:
+        print(f"[merge] {note}")
+    merged.save(args.output)
+    print(f"[merge] saved {args.output}（{len([e for e in merged if e.msgid])} 条）")
+    if args.compile:
+        mo_path = os.path.join(os.path.dirname(args.output) or ".", "ok.mo")
+        merged.save_as_mofile(mo_path)
+        print(f"[merge] compiled {mo_path}")
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -88,3 +88,20 @@ gh pr edit <n> --body $body
 5. `log_info`/`mark_task_failure` 自身不做翻译也不支持 params 填充；**带动态值的日志统一在调用侧走 tr+format**：`self.tr("模板{a}…{b}").format(a=已译文本值, b=纯数字值)`——外层模板串必须 tr（msgid=稳定模板串进 po），文本类动态值内层过 tr 后再填充，纯数字值直接填充不 tr；运行时未知文本（OCR 结果、账号名等）不过 tr 防污染收集池。通知链路（`notify=True`/`show_notification`）和 instructions 富文本构建同理。
    **纯静态硬编码文案（无占位符、无变化）禁止在调用侧加 tr**：直接 `log_info("固定中文")`——UI 显示层渲染日志时会统一翻译，调用侧再包一层 tr 属于冗余；只有带占位符、存在多种变化的模板串才需要调用侧 tr+format（gettext 必须在 format 前命中稳定 msgid）。
 6. po 出现垃圾条目时：确认来源 → 能声明式的走第 3 条；一次性清理可仿照 `tmp/clean_dynamic_po_entries.py` 删条目后重编译。
+
+## 技能清单（.agents/skills/）
+
+仓库技能按场景简要说明如下；需要时用 skill 工具加载对应技能获取完整流程：
+
+- `deploy`：提交并创建版本 tag 推送到发布远端（`deploy` / `deploy beta` / `deploy alpha`）。
+- `use-local-venv`：优先使用仓库本地 `.venv`（`uv sync` 创建、`uv run` 执行）运行 Python。
+- `ok-script-tasks`：创建/修改 ok-script 任务类（`BaseTask` / `TriggerTask`、任务配置 UI 元数据、注册）。
+- `ok-script-codegen`：根据需求描述/截图生成任务 run 方法自动化代码（OCR、模板匹配、相对点击、等待方法）。
+- `ok-script-i18n`：任务元数据/字符串 gettext 国际化（ok.po 同步与编译、lang JSON 约定、`merge_po.py` 目录冲突合并）。
+- `ok-script-ocr-lang`：OCR 语言资源与 OCR 文本修正补丁（`assets/lang/*.json` schema、active locale、`ocr_text_fix.json`）。
+- `ok-config-migration`：配置键名修改严格顺序（迁移表 → 迁移测试 → i18n → 文档 → 恢复）。
+- `ok-script-pr-review`：CodeRabbit 审阅处理（触发新审阅、等待审阅覆盖新 head、回复/解析线程、限流重试）。
+- `github-workflows`：GitHub Actions workflow YAML 编写与排查（语法陷阱、Invalid workflow、SonarCloud 规则）。
+- `github-rulesets`：仓库 rulesets（分支/tag 保护、bypass 角色、GitHub App 自动打 tag）配置与排查。
+- `github-actions-performance`：GitHub Actions 任务性能分析（checkout 版本差异、shallow-clone 副作用、tag 裁剪开销）。
+- `log-watcher-ops`：log-watcher 项目运维（Outlook HTML 日报邮件、watch_dirs 监控、每日清理、dashboard 部署与 `/ok-logs/` 反向代理）。


### PR DESCRIPTION
## 概述

把与「自动释放推荐技能」无关的开发工具与文档改动从 PR #255 拆分出来，独立成 PR：

- **AGENTS.md 技能清单**：按场景一行简介 `.agents/skills/` 下 12 个技能（任务、i18n、OCR、配置迁移、CodeRabbit 审阅、GitHub Actions、部署、运维等），便于会话开始时快速定位所需技能。
- **po 目录合并脚本 `merge_po.py`**（`.agents/skills/ok-script-i18n/scripts/`）：git merge / stash pop 场景下同一 `ok.po` 被双方修改、`ok.mo` 二进制必冲突时，按 msgid->msgstr 字典合并两侧目录；同一 msgid 两侧均有且翻译不同时取 mtime 较新一侧（`--prefer` 可覆盖），两侧独有条目全部保留，可选 `--compile` 合并后直接编译 `ok.mo`。已在 `ok-script-i18n` skill 中补充用法说明（含 `git show :3:` 取对方一侧的示例）。

均不涉及运行时代码，不影响任何任务行为。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增翻译文件合并工具，保留双方独有条目，并可按更新时间或指定优先级处理冲突。
  - 支持保存合并结果，并可选生成编译后的翻译文件。
  - 合并完成后显示冲突、追加条目及编译状态。
- **文档**
  - 更新翻译冲突处理示例，避免导出文件时出现编码问题。
  - 新增技能清单及其用途说明。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->