### PR TITLE
fix: 恢复 find_one 的 feature 别名参数修复 feature= 调用 TypeError

### DIFF
--- a/src/core/base_mixin/runtime_mixin.py
+++ b/src/core/base_mixin/runtime_mixin.py
@@ -362,6 +362,13 @@ class RuntimeMixin:
         Returns:
             Box: 置信度最高的匹配框；未匹配到时返回 None。
         """
+        # Validate feature/feature_name mutual exclusivity
+        if feature is not None and feature_name is not None:
+            raise ValueError("只能提供 feature 或 feature_name 中的一个参数，不能同时提供两者")
+        if feature is None and feature_name is None:
+            raise ValueError("必须提供 feature 或 feature_name 中的一个参数")
+
+        # Resolve alias
         if feature is not None and feature_name is None:
             feature_name = feature
         return super().find_one(feature_name, horizontal_variance, vertical_variance, threshold,

--- a/src/core/base_mixin/runtime_mixin.py
+++ b/src/core/base_mixin/runtime_mixin.py
@@ -332,6 +332,43 @@ class RuntimeMixin:
                                     template, match_method, screenshot, mask_function, frame, limit, target_height)
         return result
 
+    def find_one(self, feature_name=None, horizontal_variance=0, vertical_variance=0, threshold=0,
+                 use_gray_scale=False, box=None, canny_lower=0, canny_higher=0,
+                 frame_processor=None, template=None, mask_function=None, frame=None,
+                 match_method=cv2.TM_CCOEFF_NORMED, screenshot=False, limit=1,
+                 target_height=0, feature=None):
+        """
+        按当前分辨率映射后执行单个特征识别。
+
+        Args:
+            feature_name: 特征名称。
+            horizontal_variance: 水平容差。
+            vertical_variance: 垂直容差。
+            threshold: 匹配阈值。
+            use_gray_scale: 是否使用灰度图。
+            box: 识别框。
+            canny_lower: Canny 下限。
+            canny_higher: Canny 上限。
+            frame_processor: 额外帧处理器。
+            template: 自定义模板。
+            mask_function: 掩码函数。
+            frame: 输入帧。
+            match_method: 模板匹配方法。
+            screenshot: 是否截图后识别。
+            limit: 返回数量限制。
+            target_height: 目标缩放高度。
+            feature: feature_name 的兼容别名。
+
+        Returns:
+            Box: 置信度最高的匹配框；未匹配到时返回 None。
+        """
+        if feature is not None and feature_name is None:
+            feature_name = feature
+        return super().find_one(feature_name, horizontal_variance, vertical_variance, threshold,
+                                use_gray_scale, box, canny_lower, canny_higher, frame_processor,
+                                template, mask_function, frame, match_method, screenshot,
+                                limit, target_height)
+
     def scroll(self, x: int, y: int, count: int) -> None:
         """按屏幕绝对像素坐标滚轮。
 


### PR DESCRIPTION
### 问题

`find_one` 缺少 `feature=` 别名参数。上游 ok-script 2.0.4 的 `find_one` 首个参数是 `feature_name`，不接受 `feature` 关键字；本地覆写在 #251 清理时被误删，但 `navigation_mixin.py`、`game_flow_mixin.py`、`liaison_mixin.py`、`daily_reward_mixin.py`、`daily_boat_mixin.py` 等 10+ 处调用仍使用 `find_one(feature=...)`，运行时直接抛 `TypeError: find_one() got an unexpected keyword argument 'feature'`。

`docs/dev/API.md` 仍记录了带 `feature` 别名的 `find_one` 签名，与代码不一致。

### 修复

在 `src/core/base_mixin/runtime_mixin.py` 以 master 基线、参照 `find_feature` 覆写模式恢复本地 `find_one` 覆写：

- 完整对齐上游 `find_one` 参数顺序，末尾追加 `feature` 别名
- `feature` 与 `feature_name` 二选一传入，位置传参调用 `super().find_one`
- 分辨率后缀映射继续由链上的 `find_feature` 覆写统一处理

### 验证

- `uv run python -m unittest discover -s tests`：291 个测试全部通过
- 新增覆写签名与 `docs/dev/API.md` 记录的 `find_one` 签名一致

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新功能**
  * 新增单目标特征识别功能，支持通过特征名称或别名进行识别。
  * 支持自定义识别参数、图像处理方式及兼容参数。
  * 要求在特征名称或兼容参数中二选一，避免参数冲突。
  * 默认最多返回一个匹配结果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->