### PR TITLE
fix: 恢复 RuntimeMixin.screen_center 方法

### DIFF
--- a/src/core/BaseEfTask.py
+++ b/src/core/BaseEfTask.py
@@ -212,11 +212,13 @@ class BaseEfTask(
             super().sleep(min(remaining, 0.1))
 
     def pause(self):
+        """Pause the task and track pause time for active time calculation."""
         if not isinstance(self, TriggerTask) and self._task_pause_started_at is None:
             self._task_pause_started_at = time.monotonic()
         return super().pause()
 
     def unpause(self):
+        """Resume the task and accumulate the paused duration."""
         if self._task_pause_started_at is not None:
             self._active_time_paused_total += max(0.0, time.monotonic() - self._task_pause_started_at)
             self._task_pause_started_at = None
@@ -317,6 +319,7 @@ class BaseEfTask(
         return "background" if global_mode == "后台模式" else "foreground"
 
     def enable(self):
+        """Enable the task if it is compatible with the current input mode."""
         if self.input_mode() == "background" and getattr(self, "requires_foreground", False):
             self.log_info("后台模式下该任务需要前台操作（移动/战斗/视角），无法启用", notify=True)
             return
@@ -335,6 +338,7 @@ class BaseEfTask(
             vcenter=False,
             confidence=1.0,
     ):
+        """Create a screen box with rounded coordinate ratios for consistent positioning."""
         return super().box_of_screen(
             _round_ratio(x),
             _round_ratio(y),
@@ -363,6 +367,7 @@ class BaseEfTask(
             vcenter=False,
             confidence=1.0,
     ):
+        """Create a screen box scaled from original resolution coordinates with rounded ratios."""
         return super().box_of_screen_scaled(
             original_screen_width,
             original_screen_height,
@@ -379,13 +384,16 @@ class BaseEfTask(
         )
 
     def click_relative(self, x, y, *args, **kwargs):
+        """Click at relative screen coordinates with rounded ratios."""
         return super().click_relative(_round_ratio(x), _round_ratio(y), *args, **kwargs)
 
     def middle_click_relative(self, x, y, *args, **kwargs):
+        """Middle-click at relative screen coordinates with rounded ratios."""
         return super().middle_click_relative(_round_ratio(x), _round_ratio(y), *args, **kwargs)
 
     @property
     def runtime_locale(self) -> str | None:
+        """Get the runtime locale for this task instance."""
         return _extract_locale_from_object(self)
 
     def screenshot_timestamp_prefix(self):

--- a/src/core/BattleConfig.py
+++ b/src/core/BattleConfig.py
@@ -108,11 +108,14 @@ BATTLE_CONFIG_DESCRIPTION = {
 
 
 class BattleConfigManager:
+    """Manages battle configuration with fallback to default values."""
     def __init__(self, battle_config: dict | None = None):
         self.battle_config = battle_config or {}
 
     def update_config(self, battle_config: dict):
+        """Update the battle configuration with a new dictionary."""
         self.battle_config = battle_config or {}
 
     def get(self, key: str, default=None):
+        """Get a configuration value with fallback to default battle config."""
         return self.battle_config.get(key, DEFAULT_BATTLE_CONFIG.get(key, default))

--- a/src/core/base_mixin/game_flow_mixin.py
+++ b/src/core/base_mixin/game_flow_mixin.py
@@ -202,7 +202,7 @@ class GameFlowMixin:
                 self._logged_in = True
                 return True
             elif self.find_one(fL.monthly_card) or self.find_one(fL.monthly_card2) or self.find_one(fL.logout) or self.find_one(fL.login_reward_icon):
-                run_at_window_pos(self.get_game_hwnd(), super().click, self.width // 2, self.height // 2, 1, 0.5, 0.5)
+                run_at_window_pos(self.get_game_hwnd(), super().click, *self.screen_center(), 1, 0.5, 0.5)
                 return False
             elif close := (
                     self.find_one(fL.one_click_claim, horizontal_variance=0.1, vertical_variance=0.1)

--- a/src/core/base_mixin/runtime_mixin.py
+++ b/src/core/base_mixin/runtime_mixin.py
@@ -969,6 +969,15 @@ class RuntimeMixin:
         """
         self._dodge_with_direction('w', pre_hold=pre_hold, dodge_down_time=dodge_down_time, after_sleep=after_sleep)
 
+    def screen_center(self) -> tuple[int, int]:
+        """
+        返回当前屏幕中心点坐标。
+
+        Returns:
+            tuple[int, int]: 屏幕中心点坐标。
+        """
+        return int(self.width / 2), int(self.height / 2)
+
     def move_to_target_once(self, ocr_obj, max_step=100, min_step=20, slow_radius=200, deadzone=4):
         """
         移动一次以逼近 OCR 目标。

--- a/src/core/game_window.py
+++ b/src/core/game_window.py
@@ -28,6 +28,7 @@ def find_game_hwnd(window_config: dict, timeout: float = 10.0, interval: float =
         foreground_hwnd = win32gui.GetForegroundWindow()
 
         def collect(hwnd, _):
+            """Collect candidate window handles matching the configured criteria."""
             try:
                 if not win32gui.IsWindowVisible(hwnd):
                     return True

--- a/src/core/global_config_store.py
+++ b/src/core/global_config_store.py
@@ -232,6 +232,7 @@ def _migrate_legacy_zip_line_account_overrides() -> None:
     from src.tasks.account.account_scope_store import update_overrides
 
     def apply(data):
+        """Apply migration to account override data."""
         accounts = data.get("accounts") or {}
         if not isinstance(accounts, dict):
             return data
@@ -408,6 +409,7 @@ def migrate_task_zip_line_values_to_global(task_class_name: str) -> None:
 
 
 def get_global_config(name: str) -> Config:
+    """Get a global configuration object by name, loading it if not yet cached."""
     with _LOCK:
         option = _OPTIONS.get(name)
         if option is None:
@@ -427,6 +429,7 @@ def get_global_config(name: str) -> Config:
 
 
 def get_all_visible_configs():
+    """Get all visible (non-internal) global configurations as a sorted list."""
     configs = []
     for option in GLOBAL_CONFIG_OPTIONS:
         if not option.name.startswith("_"):

--- a/src/data/FeatureList.py
+++ b/src/data/FeatureList.py
@@ -2,6 +2,7 @@ from enum import Enum
 
 
 class FeatureList(str, Enum):
+    """Enumeration of all feature labels used for image recognition and game automation."""
     akekuri_contact = 'akekuri_contact'
     alesh_contact = 'alesh_contact'
     all_receive = 'all_receive'

--- a/src/data/characters_utils.py
+++ b/src/data/characters_utils.py
@@ -33,6 +33,7 @@ def _get_localized_character_name(lang_accessor: Any, char_key: str, fallback: s
 
 
 def get_contact_list_with_feature_list(lang_accessor=None) -> dict[str, str]:
+    """Get a mapping of localized character names to their feature labels for contact interactions."""
     feature_set = {f.value for f in FeatureList}  # 取 FeatureList 枚举的所有值
 
     en_to_zh = {

--- a/src/data/delivery_area_service.py
+++ b/src/data/delivery_area_service.py
@@ -38,6 +38,7 @@ def _get_area_config(area_name: str) -> dict:
 
 
 def get_delivery_locations(area_name: str, lang_accessor=None) -> list[str]:
+    """Get the list of delivery locations for a specific area, optionally localized."""
     locations = _get_area_config(area_name)["delivery_locations"]
     if lang_accessor is None:
         return list(locations)
@@ -45,6 +46,7 @@ def get_delivery_locations(area_name: str, lang_accessor=None) -> list[str]:
 
 
 def get_delivery_targets(area_name: str, lang_accessor=None) -> list[str]:
+    """Get the list of all delivery targets across all locations in an area, optionally localized."""
     area_config = _get_area_config(area_name)
     targets_by_location = area_config["delivery_targets_by_location"]
     targets = []
@@ -56,6 +58,7 @@ def get_delivery_targets(area_name: str, lang_accessor=None) -> list[str]:
 
 
 def get_ocr_priority_locations(area_name: str, lang_accessor=None) -> list[str]:
+    """Get the list of priority locations for OCR scanning in an area, optionally localized."""
     locations = _get_area_config(area_name)["ocr_priority_locations"]
     if lang_accessor is None:
         return list(locations)
@@ -63,6 +66,7 @@ def get_ocr_priority_locations(area_name: str, lang_accessor=None) -> list[str]:
 
 
 def get_full_cycle_targets(area_name: str, location_name: str, lang_accessor=None) -> list[str]:
+    """Get the full cycle delivery targets for a specific location within an area, optionally localized."""
     targets = _get_area_config(area_name)["delivery_targets_by_location"].get(location_name, [])
     if lang_accessor is None:
         return list(targets)
@@ -70,6 +74,7 @@ def get_full_cycle_targets(area_name: str, location_name: str, lang_accessor=Non
 
 
 def extract_delivery_location(text: str, area_name: str, lang_accessor=None) -> str | None:
+    """Extract the canonical location name from text by matching against known locations."""
     canonical_locations = get_delivery_locations(area_name)
     localized_locations = get_delivery_locations(area_name, lang_accessor=lang_accessor)
     for canonical_name, localized_name in zip(canonical_locations, localized_locations):
@@ -86,6 +91,7 @@ def get_transfer_search_area(location_name: str | None, area_name: str) -> dict 
 
 
 def get_task_model_area(area_name: str, lang_accessor=None) -> str:
+    """Get the task model area name for an area, optionally localized."""
     task_model_area = _get_area_config(area_name).get("task_model_area", area_name)
     if lang_accessor is None:
         return task_model_area
@@ -111,12 +117,14 @@ def _normalize_matcher_to_pattern(matcher, fallback_text: str) -> re.Pattern:
 
 
 def get_delivery_target_ocr_pattern(_area_name: str, target_name: str, lang_accessor=None) -> re.Pattern:
+    """Get the compiled OCR pattern for matching a delivery target, optionally localized."""
     if lang_accessor is not None:
         return _normalize_matcher_to_pattern(get_world_map_matcher(lang_accessor, target_name), target_name)
     return compile_ocr_pattern(target_name)
 
 
 def get_accept_feature_labels(area_name: str, target_ticket_num: str) -> list[str]:
+    """Get the feature labels for accepting delivery orders in an area with a target ticket price."""
     area_code = _get_area_config(area_name).get("feature_label_area_code")
     price_code = format_delivery_ticket_price_code(target_ticket_num)
     if not area_code or not price_code:

--- a/src/data/item_map_query.py
+++ b/src/data/item_map_query.py
@@ -45,14 +45,17 @@ def _load_item_names() -> list[str]:
 
 
 def get_supported_item_names() -> list[str]:
+    """Get the list of all supported item names for map queries."""
     return list(_load_item_names())
 
 
 def get_supported_map_types() -> list[str]:
+    """Get the list of all supported map types available in the item map data."""
     return list(_load_summary().keys())
 
 
 def search_item_names(keyword: str) -> list[str]:
+    """Search for item names containing the specified keyword (case-insensitive)."""
     keyword = keyword.lower()
 
     return [

--- a/src/data/lang/__init__.py
+++ b/src/data/lang/__init__.py
@@ -31,6 +31,7 @@ LocaleCode = Enum("LocaleCode", {name: name for name in SUPPORTED_LOCALES}, type
 
 
 def get_supported_locales() -> tuple[str, ...]:
+    """Get a tuple of all supported locale codes that are currently active."""
     return SUPPORTED_LOCALES
 
 
@@ -76,6 +77,7 @@ def _parse_lang_value(v: Any) -> Any:
 
 
 class LangNode:
+    """Represents a language node that can contain string, pattern, or terms data."""
     def __init__(self, data: dict | None):
         self._data = data or {}
 
@@ -102,18 +104,22 @@ class LangNode:
 
     @property
     def string(self) -> str | None:
+        """Get the string value from this language node, if present."""
         return self._data.get("string")
 
     @property
     def pattern(self) -> str | None:
+        """Get the pattern value from this language node, if present."""
         return self._data.get("pattern")
 
     @property
     def terms(self) -> list | None:
+        """Get the terms list from this language node, if present."""
         return self._data.get("terms")
 
 
 class LangModule:
+    """Represents a language module containing multiple language keys and their localized values."""
     def __init__(self, data: dict):
         self._data = data or {}
 
@@ -133,6 +139,7 @@ class LangModule:
 
 
 class LangAccessor(_LangAccessorTyped):
+    """Accessor for loading and accessing language modules for a specific locale."""
     def __init__(self, locale: str | None = None):
         self.locale = _normalize_locale(locale)
         self._cache: dict[str, LangModule] = {}
@@ -237,6 +244,7 @@ def _locale_from_obj(obj: Any) -> str | None:
 
 
 def get_lang_accessor(obj_or_locale: Any = None) -> LangAccessor:
+    """Get a language accessor for the specified locale or object's locale attribute."""
     locale = None
     if isinstance(obj_or_locale, str):
         locale = obj_or_locale

--- a/src/gui/AccountConfigTab.py
+++ b/src/gui/AccountConfigTab.py
@@ -64,13 +64,16 @@ class InMemoryConfig(dict):
         self.default = defaults
 
     def get_default(self, key):
+        """Get the default value for a configuration key."""
         return self.default.get(key)
 
     def has_user_config(self):
+        """Check if any user-defined (non-internal) configuration keys exist."""
         return any(not str(key).startswith("_") for key in self.keys())
 
 
 class AccountConfigTab(CustomTab):
+    """Tab for managing per-account configuration overrides and account list."""
     ALWAYS_HIDDEN_CONFIG_KEYS = {"多账户模式", "多账户独立配置", "账号列表"}
 
     def __init__(self):
@@ -101,6 +104,7 @@ class AccountConfigTab(CustomTab):
 
     @property
     def name(self):
+        """Get the tab name key for translation."""
         # MainWindow 会对 tab 的 name 统一调用 self.app.tr(name)，
         # 这里必须返回源 key（"账号配置"）而非已翻译文本，
         # 否则会对翻译结果二次 tr()，把繁体 key 当作待翻译字符串收集进 ok.po。
@@ -108,17 +112,21 @@ class AccountConfigTab(CustomTab):
 
     @property
     def position(self):
+        """Get the navigation position for this tab."""
         return NavigationItemPosition.TOP
 
     @property
     def add_after_default_tabs(self):
+        """Indicate whether this tab should be added after default tabs."""
         return False
 
     @property
     def icon(self):
+        """Get the icon for this tab."""
         return FluentIcon.PEOPLE
 
     def showEvent(self, event):
+        """Handle widget show event, loading or syncing configuration data."""
         super().showEvent(event)
         if not self._loaded_once and self.executor is not None:
             self._loaded_once = True
@@ -127,6 +135,7 @@ class AccountConfigTab(CustomTab):
             self.sync_from_source()
 
     def sync_from_source(self):
+        """Synchronize account configuration from the source without rebuilding task list."""
         self._save_pending_changes()
         self._building = True
         try:
@@ -266,6 +275,7 @@ class AccountConfigTab(CustomTab):
 
     @staticmethod
     def _parse_accounts(account_list_text: str) -> list[Dict[str, str]]:
+        """Parse account list text into structured account dictionaries with username and password."""
         accounts: list[Dict[str, str]] = []
         seen = set()
         for entry in parse_account_list_text(account_list_text):
@@ -276,6 +286,7 @@ class AccountConfigTab(CustomTab):
         return accounts
 
     def _resolve_account_key_by_username(self, username: str) -> str:
+        """Resolve the internal account key from a username by looking up the account registry."""
         username = username.strip()
         if not username:
             return ""
@@ -292,6 +303,7 @@ class AccountConfigTab(CustomTab):
         return ""
 
     def _get_account_name_by_key(self, account_key: str) -> str:
+        """Get the account display name (username) from the internal account key."""
         if not account_key:
             return ""
 
@@ -305,10 +317,12 @@ class AccountConfigTab(CustomTab):
 
     @staticmethod
     def _is_supported_value(value: Any) -> bool:
+        """Check if a value is a supported configuration type."""
         return isinstance(value, (bool, int, float, str, list))
 
     @staticmethod
     def _config_key_set(task, attribute: str) -> set[str]:
+        """Extract configuration keys from a task attribute, handling strings, lists, tuples, and sets."""
         value = getattr(task, attribute, None)
         if isinstance(value, str):
             return {value}
@@ -318,9 +332,11 @@ class AccountConfigTab(CustomTab):
 
     @staticmethod
     def _task_storage_name(task) -> str:
+        """Get the storage name for a task used in account override keys."""
         return str(getattr(task, "account_override_name", task.__class__.__name__))
 
     def _account_config_schema(self, task, task_override: Dict[str, Any]) -> Dict[str, Any]:
+        """Build the configuration schema for a task including default and account-specific settings."""
         schema = dict(task.default_config)
         extra_defaults = getattr(task, "account_config_defaults", None)
         if isinstance(extra_defaults, dict):
@@ -337,6 +353,7 @@ class AccountConfigTab(CustomTab):
         return schema
 
     def _account_config_rules(self, task) -> tuple[set[str], set[str]]:
+        """Determine configuration key blacklist and whitelist for account overrides."""
         blacklist = self.ALWAYS_HIDDEN_CONFIG_KEYS | self._config_key_set(task, "account_config_blacklist")
         whitelist = self._config_key_set(task, "account_config_whitelist")
 
@@ -365,6 +382,7 @@ class AccountConfigTab(CustomTab):
 
     @staticmethod
     def _account_config_base_value(task, key: str, default_value: Any) -> Any:
+        """Get the base configuration value for a key, falling back to default if not in task config."""
         if key in task.config:
             return dict.get(task.config, key, default_value)
         provider = getattr(task, "get_account_config_base_value", None)
@@ -374,6 +392,7 @@ class AccountConfigTab(CustomTab):
 
     @staticmethod
     def _coerce_like(base_value: Any, value: Any) -> Any:
+        """Coerce a value to match the type of the base value, with fallback for incompatible types."""
         if base_value is None or value is None:
             return value
 
@@ -417,6 +436,7 @@ class AccountConfigTab(CustomTab):
         return value if isinstance(value, type(base_value)) else base_value
 
     def _collect_tasks(self):
+        """Collect all tasks that support multi-account configuration from the executor."""
         if self.executor is None:
             return []
 
@@ -434,6 +454,7 @@ class AccountConfigTab(CustomTab):
         return tasks
 
     def refresh_from_source(self):
+        """Fully refresh account configuration and task list from source data."""
         if not self._ensure_executor():
             return
 
@@ -458,6 +479,7 @@ class AccountConfigTab(CustomTab):
             self._building = False
 
     def save_base_settings(self):
+        """Save the account list and synchronize account registry."""
         if not self._ensure_executor():
             return
 
@@ -489,18 +511,22 @@ class AccountConfigTab(CustomTab):
         self._set_status(status)
 
     def _current_account_key(self) -> str:
+        """Get the internal account key for the currently selected account."""
         display = self.account_selector.currentText().strip()
         return self.account_display_to_key.get(display, "")
 
     def _current_account_name(self) -> str:
+        """Get the display name (username) for the currently selected account."""
         display = self.account_selector.currentText().strip()
         return self.account_display_to_name.get(display, "")
 
     def _current_task(self):
+        """Get the task object for the currently selected task."""
         display = self.task_selector.currentText().strip()
         return self.task_map.get(display)
 
     def rebuild_account_selector(self, keep_selection: bool = True):
+        """Rebuild the account selector dropdown, optionally preserving the current selection."""
         current_key = self._current_account_key() if keep_selection else ""
 
         raw_items: list[tuple[str, str]] = []
@@ -560,6 +586,7 @@ class AccountConfigTab(CustomTab):
             self.account_selector.blockSignals(False)
 
     def rebuild_task_selector(self, keep_selection: bool = True):
+        """Rebuild the task selector dropdown, optionally preserving the current selection."""
         current_task = self._current_task()
         current_class_name = AccountConfigTab._task_storage_name(current_task) if keep_selection and current_task else ""
 
@@ -592,6 +619,7 @@ class AccountConfigTab(CustomTab):
             self.task_selector.blockSignals(False)
 
     def on_account_changed(self, _):
+        """Handle account selector change event, saving pending changes and reloading task editor."""
         if self._building:
             return
         self._save_pending_changes()
@@ -599,6 +627,7 @@ class AccountConfigTab(CustomTab):
         self.render_task_editor()
 
     def load_current_map_content(self):
+        """Load the map sync content for the currently selected account."""
         account_key = self._current_account_key()
         account_name = self._current_account_name()
         self.current_map_account_key = account_key
@@ -610,12 +639,14 @@ class AccountConfigTab(CustomTab):
         self.map_content_edit.setText(self.current_map_value)
 
     def on_task_changed(self, _):
+        """Handle task selector change event, saving pending changes and reloading task editor."""
         if self._building:
             return
         self._save_pending_changes()
         self.render_task_editor()
 
     def on_view_mode_changed(self, _):
+        """Handle view mode switch change event (all config vs. diff only)."""
         if self._building:
             return
         self._save_pending_changes()
@@ -699,6 +730,7 @@ class AccountConfigTab(CustomTab):
         self._set_current_task_editor_enabled(not bool(task and task.running))
 
     def render_task_editor(self):
+        """Render the task configuration editor for the currently selected account and task."""
         self._hide_task_editor()
         self.current_virtual_config = None
         self.current_task = None
@@ -896,12 +928,14 @@ class AccountConfigTab(CustomTab):
         return changed
 
     def save_current_account_config(self):
+        """Save the currently edited account configuration and map content."""
         if not self.current_map_account_key and not self.current_account_key:
             self._set_status(og.app.tr("请先选择账号"))
             return
         self._save_pending_changes(show_status=True, cleanup_blacklist=True)
 
     def clear_current_task_override(self):
+        """Clear the configuration override for the current account and task combination."""
         account_key = self._current_account_key()
         account_name = self._current_account_name()
         task = self._current_task()
@@ -945,6 +979,7 @@ class AccountConfigTab(CustomTab):
         ))
 
     def clear_current_account_overrides(self):
+        """Clear all task configuration overrides for the currently selected account."""
         account_key = self._current_account_key()
         account_name = self._current_account_name()
         if not account_key:

--- a/src/interaction/ScreenPosition.py
+++ b/src/interaction/ScreenPosition.py
@@ -12,24 +12,24 @@ class ScreenPosition:
     """
 
     def __init__(self, parent):
-        self.parent = parent  # parent 必须有 .width 和 .height
+        self.parent = parent  # parent 必须有 .screen_center（经 .width/.height 计算）
 
     # ---------- 固定位置 ----------
     @property
     def top_left(self) -> Box:
-        return Box(x=0, y=0, to_x=self.parent.width // 2, to_y=self.parent.height // 2)
+        return Box(x=0, y=0, to_x=self.parent.screen_center()[0], to_y=self.parent.screen_center()[1])
 
     @property
     def top_right(self) -> Box:
-        return Box(x=self.parent.width // 2, y=0, to_x=self.parent.width, to_y=self.parent.height // 2)
+        return Box(x=self.parent.screen_center()[0], y=0, to_x=self.parent.width, to_y=self.parent.screen_center()[1])
 
     @property
     def bottom_left(self) -> Box:
-        return Box(x=0, y=self.parent.height // 2, to_x=self.parent.width // 2, to_y=self.parent.height)
+        return Box(x=0, y=self.parent.screen_center()[1], to_x=self.parent.screen_center()[0], to_y=self.parent.height)
 
     @property
     def bottom_right(self) -> Box:
-        return Box(x=self.parent.width // 2, y=self.parent.height // 2, to_x=self.parent.width, to_y=self.parent.height)
+        return Box(x=self.parent.screen_center()[0], y=self.parent.screen_center()[1], to_x=self.parent.width, to_y=self.parent.height)
 
     @property
     def bottom_right_quarter(self) -> Box:
@@ -37,19 +37,19 @@ class ScreenPosition:
 
     @property
     def left(self) -> Box:
-        return Box(x=0, y=0, to_x=self.parent.width // 2, to_y=self.parent.height)
+        return Box(x=0, y=0, to_x=self.parent.screen_center()[0], to_y=self.parent.height)
 
     @property
     def right(self) -> Box:
-        return Box(x=self.parent.width // 2, y=0, to_x=self.parent.width, to_y=self.parent.height)
+        return Box(x=self.parent.screen_center()[0], y=0, to_x=self.parent.width, to_y=self.parent.height)
 
     @property
     def top(self) -> Box:
-        return Box(x=0, y=0, to_x=self.parent.width, to_y=self.parent.height // 2)
+        return Box(x=0, y=0, to_x=self.parent.width, to_y=self.parent.screen_center()[1])
 
     @property
     def bottom(self) -> Box:
-        return Box(x=0, y=self.parent.height // 2, to_x=self.parent.width, to_y=self.parent.height)
+        return Box(x=0, y=self.parent.screen_center()[1], to_x=self.parent.width, to_y=self.parent.height)
 
     @property
     def center(self) -> Box:

--- a/src/tasks/account/account_scope_store.py
+++ b/src/tasks/account/account_scope_store.py
@@ -20,6 +20,7 @@ _CACHE_DATA: Dict[str, Any] = copy.deepcopy(_EMPTY_STORE)
 
 
 def get_store_path() -> str:
+    """Get the file path to the account-scoped overrides storage file."""
     return _STORE_PATH
 
 
@@ -115,6 +116,7 @@ def _parse_account_list_text_internal(account_list_text: Any) -> Tuple[List[Dict
 
 
 def parse_account_list_text(account_list_text: Any) -> List[Dict[str, str]]:
+    """Parse account list text into a list of account dictionaries with username and password fields."""
     entries, _ = _parse_account_list_text_internal(account_list_text)
     return entries
 
@@ -369,6 +371,7 @@ def _sync_account_list_text_on_data(data: Dict[str, Any], text: str) -> Tuple[Di
 
 
 def load_overrides(force: bool = False) -> Dict[str, Any]:
+    """Load account-scoped configuration overrides from storage, using cache unless force is True."""
     global _CACHE_MTIME
     global _CACHE_DATA
 
@@ -393,6 +396,7 @@ def load_overrides(force: bool = False) -> Dict[str, Any]:
 
 
 def save_overrides(data: Dict[str, Any]) -> Dict[str, Any]:
+    """Save account-scoped configuration overrides to storage and update cache."""
     global _CACHE_MTIME
     global _CACHE_DATA
 
@@ -406,6 +410,7 @@ def save_overrides(data: Dict[str, Any]) -> Dict[str, Any]:
 
 
 def update_overrides(updater: Callable[[Dict[str, Any]], Dict[str, Any]]) -> Dict[str, Any]:
+    """Update account-scoped overrides by applying an updater function to the current data."""
     global _CACHE_MTIME
     global _CACHE_DATA
 
@@ -427,6 +432,7 @@ def update_overrides(updater: Callable[[Dict[str, Any]], Dict[str, Any]]) -> Dic
 
 
 def sync_account_list_text(text: str) -> Dict[str, Any]:
+    """Synchronize the account list text with the account registry, creating or reusing account IDs."""
     summary: Dict[str, Any] = {}
 
     def apply(data):
@@ -442,6 +448,7 @@ def sync_account_list_text(text: str) -> Dict[str, Any]:
 
 
 def resolve_account_id(username: str, create_if_missing: bool = False) -> str:
+    """Resolve the internal account ID for a username, optionally creating a new ID if not found."""
     account_name = _clean_username(username)
     if not account_name:
         return ""
@@ -465,6 +472,7 @@ def resolve_account_id(username: str, create_if_missing: bool = False) -> str:
 
 
 def get_account_task_overrides(account: str, task_name: str, account_name: str = "") -> Dict[str, Any]:
+    """Get configuration overrides for a specific account and task combination."""
     if not task_name:
         return {}
 
@@ -517,6 +525,7 @@ def _resolve_account_id_for_read(data: Dict[str, Any], account: str, account_nam
 
 
 def get_account_map_content(account: str, account_name: str = "") -> str:
+    """Get the map sync content (hg/check data.content) for a specific account."""
     account_key = _clean_username(account)
     account_name = _clean_username(account_name)
     if not account_key and not account_name:
@@ -535,6 +544,7 @@ def get_account_map_content(account: str, account_name: str = "") -> str:
 
 
 def set_account_map_content(account: str, content: str) -> None:
+    """Set the map sync content for a specific account."""
     if not account:
         return
 
@@ -571,6 +581,7 @@ def _resolve_account_id_for_write(data: Dict[str, Any], account: str) -> str:
 
 
 def set_account_task_overrides(account: str, task_name: str, values: Dict[str, Any]) -> None:
+    """Set configuration overrides for a specific account and task combination."""
     if not account or not task_name:
         return
 
@@ -592,6 +603,7 @@ def set_account_task_overrides(account: str, task_name: str, values: Dict[str, A
 
 
 def remove_account_task_overrides(account: str, task_name: str) -> None:
+    """Remove configuration overrides for a specific account and task combination."""
     if not account or not task_name:
         return
 
@@ -612,15 +624,18 @@ def remove_account_task_overrides(account: str, task_name: str) -> None:
 
 
 def list_accounts() -> list[str]:
+    """List all account IDs that have configuration overrides."""
     data = load_overrides()
     return list((data.get("accounts") or {}).keys())
 
 
 def get_account_list_text() -> str:
+    """Get the stored account list text (one account per line)."""
     data = load_overrides()
     value = data.get("account_list_text", "")
     return value if isinstance(value, str) else str(value)
 
 
 def set_account_list_text(text: str) -> None:
+    """Set the account list text and synchronize with the account registry."""
     sync_account_list_text(text)

--- a/src/tasks/mixin/navigation_mixin.py
+++ b/src/tasks/mixin/navigation_mixin.py
@@ -463,15 +463,14 @@ class NavigationMixin(SearchMixin):
                 if is_num:
                     result.y = result.y - int(self.height * ((525 - 486) / 1080))
                 if only_y:
-                    result.x = self.width // 2 - result.width // 2
+                    result.x = self.screen_center()[0] - result.width // 2
                 if only_x:
-                    result.y = self.height // 2 - result.height // 2
+                    result.y = self.screen_center()[1] - result.height // 2
                 target_center = (
                     result.x + result.width // 2,
                     result.y + result.height // 2,
                 )
-                # 屏幕中心（与 RuntimeMixin.screen_center 一致的内联计算）
-                screen_center_pos = (int(self.width / 2), int(self.height / 2))
+                screen_center_pos = self.screen_center()
                 last_target = result
                 last_target_fail_count = 0
                 # 计算偏移量
@@ -503,7 +502,7 @@ class NavigationMixin(SearchMixin):
                     decay = 0.9 ** last_target_fail_count
                     # 计算目标中心到屏幕中心的偏移
 
-                    screen_center_x, screen_center_y = int(self.width / 2), int(self.height / 2)
+                    screen_center_x, screen_center_y = self.screen_center()
                     offset_x = int((screen_center_x - last_target.x) * decay)
                     offset_y = int((screen_center_y - last_target.y) * decay)
                     offset_width = int(last_target.width / 2 * decay)

--- a/src/tasks/mixin/navigation_mixin.py
+++ b/src/tasks/mixin/navigation_mixin.py
@@ -470,7 +470,7 @@ class NavigationMixin(SearchMixin):
                     result.x + result.width // 2,
                     result.y + result.height // 2,
                 )
-                # 屏幕中心（原 RuntimeMixin.screen_center 已移除，直接内联计算）
+                # 屏幕中心（与 RuntimeMixin.screen_center 一致的内联计算）
                 screen_center_pos = (int(self.width / 2), int(self.height / 2))
                 last_target = result
                 last_target_fail_count = 0


### PR DESCRIPTION
## 问题

`DeliveryTask` 滑索流程（`zip_line_list_go` → `align_ocr_or_find_target_to_center` → `move_to_target_once`）运行时崩溃：

```
AttributeError: 'DeliveryTask' object has no attribute 'screen_center'
```

## 原因

#251（refactor: 动态值日志统一 tr+format 并清理 runtime_mixin 冗余封装）删除了 `RuntimeMixin.screen_center` 方法，但 `move_to_target_once` 仍把 `self.screen_center` 作为**可调用对象**传给 `Mouse.move_to_target_once_impl`（内部执行 `screen_center_func()`）。删除不完整，导致所有走该路径的调用（如送货滑索）运行时缺属性。

## 修复

- 恢复 `RuntimeMixin.screen_center`：`return int(self.width / 2), int(self.height / 2)`（与 #251 之前一致，且满足 `screen_center_func()` 可调用契约）
- 同步修正 `navigation_mixin` 中「原 RuntimeMixin.screen_center 已移除」的过期注释

不影响其他行为。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增获取当前窗口屏幕中心坐标的功能，返回整数格式的横纵坐标。

- **改进**
  - 统一目标校正、登录弹窗及固定位置的屏幕中心计算方式，提升相关交互定位的一致性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->