### PR TITLE
fix: 滑索架查找后退优先，strafe_search 每次尝试归正

### DIFF
--- a/src/tasks/mixin/search_mixin.py
+++ b/src/tasks/mixin/search_mixin.py
@@ -74,10 +74,11 @@ class SearchMixin(BaseEfTask):
                 if start is not None and self.active_time() - start >= time_out:
                     self.move_keys(opposite[key], duration=duration)  # 超时前归正回原位
                     return None
-                if result := check_func():  # 命中时停在发现位置
-                    if start is not None and self.active_time() - start >= time_out:
-                        self.move_keys(opposite[key], duration=duration)
-                        return None
+                result = check_func()
+                if start is not None and self.active_time() - start >= time_out:
+                    self.move_keys(opposite[key], duration=duration)  # 超时归正回原位
+                    return None
+                if result:  # 命中时停在发现位置
                     return result
                 self.move_keys(opposite[key], duration=duration)  # 未命中反向归正回原位
         return None

--- a/src/tasks/mixin/search_mixin.py
+++ b/src/tasks/mixin/search_mixin.py
@@ -65,7 +65,11 @@ class SearchMixin(BaseEfTask):
         opposite = {"w": "s", "s": "w", "a": "d", "d": "a"}
         start = self.active_time() if time_out > 0 else None
         count = 0
-        if result := check_func():  # 先原地检测一次
+        result = check_func()  # 先原地检测一次
+        # 首次检测也可能跨过截止线：原地路径无需归正，超时直接返回
+        if start is not None and self.active_time() - start >= time_out:
+            return None
+        if result:
             return result
         while passes is None or count < passes * len(keys):
             for key in keys:
@@ -75,7 +79,7 @@ class SearchMixin(BaseEfTask):
                     self.move_keys(opposite[key], duration=duration)  # 超时前归正回原位
                     return None
                 result = check_func()
-                # 无论命中与否，检测后立即校验截止时间：check_func 自身耗时可能跨过截止线
+                # 无论命中与否, 检测后立即校验截止时间: check_func 自身耗时可能跨过截止线
                 if start is not None and self.active_time() - start >= time_out:
                     self.move_keys(opposite[key], duration=duration)  # 超时先归正回原位
                     return None

--- a/src/tasks/mixin/search_mixin.py
+++ b/src/tasks/mixin/search_mixin.py
@@ -71,9 +71,13 @@ class SearchMixin(BaseEfTask):
             for key in keys:
                 self.move_keys(key, duration=duration)
                 count += 1
+                if start is not None and self.active_time() - start >= time_out:
+                    self.move_keys(opposite[key], duration=duration)  # 超时前归正回原位
+                    return None
                 if result := check_func():  # 命中时停在发现位置
+                    if start is not None and self.active_time() - start >= time_out:
+                        self.move_keys(opposite[key], duration=duration)
+                        return None
                     return result
                 self.move_keys(opposite[key], duration=duration)  # 未命中反向归正回原位
-                if start is not None and self.active_time() - start >= time_out:
-                    return None
         return None

--- a/src/tasks/mixin/search_mixin.py
+++ b/src/tasks/mixin/search_mixin.py
@@ -50,11 +50,11 @@ class SearchMixin(BaseEfTask):
         keys=("w", "a", "s", "d"),
         time_out: float = -1,
     ):
-        """WASD 轻微移动搜索，先检测再移动，命中即返回其结果。
+        """WASD 轻微移动搜索，每次方向尝试移动后检测，未命中则反向归正回原位。
 
         Args:
             check_func: 无参回调，返回真值表示命中（可直接返回检测结果）。
-            passes: 各方向往复轮数，默认 3 轮；None 表示不限制轮数（配合 time_out 使用）。
+            passes: 各方向尝试轮数，默认 3 轮；None 表示不限制轮数（配合 time_out 使用）。
             duration: 每次按移动键的持续秒数。
             keys: 依次尝试的移动键，默认 W/A/S/D 前后左右。
             time_out: 总搜索时限（秒），<=0 表示不限制。
@@ -62,15 +62,18 @@ class SearchMixin(BaseEfTask):
         Returns:
             check_func 的命中结果；未命中返回 None。
         """
+        opposite = {"w": "s", "s": "w", "a": "d", "d": "a"}
         start = self.active_time() if time_out > 0 else None
         count = 0
+        if result := check_func():  # 先原地检测一次
+            return result
         while passes is None or count < passes * len(keys):
             for key in keys:
-                result = check_func()
-                if result:
-                    return result
+                self.move_keys(key, duration=duration)
                 count += 1
+                if result := check_func():  # 命中时停在发现位置
+                    return result
+                self.move_keys(opposite[key], duration=duration)  # 未命中反向归正回原位
                 if start is not None and self.active_time() - start >= time_out:
                     return None
-                self.move_keys(key, duration=duration)
         return None

--- a/src/tasks/mixin/search_mixin.py
+++ b/src/tasks/mixin/search_mixin.py
@@ -75,8 +75,9 @@ class SearchMixin(BaseEfTask):
                     self.move_keys(opposite[key], duration=duration)  # 超时前归正回原位
                     return None
                 result = check_func()
+                # 无论命中与否，检测后立即校验截止时间：check_func 自身耗时可能跨过截止线
                 if start is not None and self.active_time() - start >= time_out:
-                    self.move_keys(opposite[key], duration=duration)  # 超时归正回原位
+                    self.move_keys(opposite[key], duration=duration)  # 超时先归正回原位
                     return None
                 if result:  # 命中时停在发现位置
                     return result

--- a/src/tasks/mixin/zip_line_mixin.py
+++ b/src/tasks/mixin/zip_line_mixin.py
@@ -209,6 +209,7 @@ class ZipLineMixin(NavigationMixin):
                     ),
                     passes=1,
                     duration=0.1,
+                    keys=("s", "w", "a", "d"),  # 后退优先：落点常越过滑索架，后退最容易重新看到
                 )
                 if result:
                     self.press_key("v", after_sleep=1)


### PR DESCRIPTION
### 问题

1. **滑索架查找前进优先**：`zip_line_list_go` 中找「登上滑索架」的 `strafe_search` 未指定 keys，走默认 `("w", "a", "s", "d")` 前进优先。而传送/滑索落点常越过滑索架，后退最容易重新看到（`DeliveryTask._find_zip_line_board_button` 早已用后退优先 `("s", "w", "a", "d")`，取货后查找更是纯 `("s",)`）。
2. **踱步搜索不归正**：`strafe_search` 原循环为「检测→移动」连续执行，默认顺序下 W 后紧跟 A（而非抵消键 S），角色斜向漂移、越走越偏，每次尝试不回原位。

### 修复

- `zip_line_mixin.py`：找「登上滑索架」的 `strafe_search` 显式传 `keys=("s", "w", "a", "d")` 后退优先。
- `search_mixin.py`：重构 `strafe_search` 为「原地先检测一次 → 每次方向尝试 = 移动→检测→未命中按反方向键归正回原位」，命中时停在发现位置不归正（避免把目标走出交互范围）。`passes`/`time_out` 语义保持不变。

### 验证

- `uv run python -m unittest discover -s tests`：291 个测试全部通过
- 临时桩测试确认：未命中时移动序列成对归正（`w,s / a,d / s,w / d,a`），命中时只移动一次即停

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **改进**
  - 优化搜索检测时序：首次检测结果保存后再判断超时，若检测跨过截止时间，即使命中也会结束搜索并返回空结果。
  - 移动后的检测完成后立即校验超时；若超时则自动归正并结束，未超时时停留在发现位置。
  - 调整滑索目标搜索的横移按键顺序，优化特定场景下的移动表现。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->