### PR TITLE
fix: ensure_main 两段稳定检查——疑似确认后 2 秒稳定作为最终确认

### DIFF
--- a/src/core/base_mixin/game_flow_mixin.py
+++ b/src/core/base_mixin/game_flow_mixin.py
@@ -248,6 +248,9 @@ class GameFlowMixin:
         2. 第二段（最终确认）：仅在第一段通过后执行，主界面状态须持续 2 秒。
 
         两段检查共享同一时间预算（time_out），确保总耗时不超过指定超时时间。
+        恢复阶段（按 ESC 返回）在总预算内循环执行两段检查：第二段未通过时
+        回到第一段继续恢复等待，直到总超时，避免主界面刚出现时图标未稳定
+        匹配导致提前失败。
 
         Args:
             esc: 是否在失败时执行返回键处理。
@@ -299,14 +302,21 @@ class GameFlowMixin:
 
         if not result and self.active_time() - start < time_out:
             self._next_main_recovery_time = self.active_time()
-            result = self.wait_until(
-                lambda: main_suspected(esc),
-                time_out=max(0.01, time_out - (self.active_time() - start)),
-                settle_time=0,
-                raise_if_not_found=False,
-            )
-            if result:
-                result = main_stable(esc)
+            # 恢复阶段：循环两段检查直到总预算耗尽，第二段失败不中断恢复
+            while self.active_time() - start < time_out:
+                result = self.wait_until(
+                    lambda: main_suspected(esc),
+                    time_out=max(0.01, time_out - (self.active_time() - start)),
+                    settle_time=0,
+                    raise_if_not_found=False,
+                )
+                if not result:
+                    break
+                # 最终确认只观察不按键，避免返回键干扰刚出现的稳定状态
+                result = main_stable(False)
+                if result:
+                    break
+                self.log_info("主界面第二段稳定检查未通过，继续恢复等待")
 
         if not result:
             raise Exception("Please start in game world and in team!")

--- a/src/core/base_mixin/game_flow_mixin.py
+++ b/src/core/base_mixin/game_flow_mixin.py
@@ -304,9 +304,12 @@ class GameFlowMixin:
             self._next_main_recovery_time = self.active_time()
             # 恢复阶段：循环两段检查直到总预算耗尽，第二段失败不中断恢复
             while self.active_time() - start < time_out:
+                remaining = time_out - (self.active_time() - start)
+                if remaining <= 0:
+                    break
                 result = self.wait_until(
                     lambda: main_suspected(esc),
-                    time_out=max(0.01, time_out - (self.active_time() - start)),
+                    time_out=remaining,
                     settle_time=0,
                     raise_if_not_found=False,
                 )

--- a/src/core/base_mixin/game_flow_mixin.py
+++ b/src/core/base_mixin/game_flow_mixin.py
@@ -247,6 +247,8 @@ class GameFlowMixin:
            过滤加载/返回动画中的单帧闪屏误检；
         2. 第二段（最终确认）：仅在第一段通过后执行，主界面状态须持续 2 秒。
 
+        两段检查共享同一时间预算（time_out），确保总耗时不超过指定超时时间。
+
         Args:
             esc: 是否在失败时执行返回键处理。
             time_out: 等待主界面的总超时时间。
@@ -271,10 +273,17 @@ class GameFlowMixin:
 
         def main_stable(use_esc):
             # 第二段稳定检查（最终确认）：仅在第一段通过后执行，状态须持续 2 秒
+            # 使用剩余时间预算，避免超出总 time_out
+            remaining = time_out - (self.active_time() - start)
+            if remaining <= 0:
+                return False
+            # 理想稳定时间为 2 秒，但不超过剩余预算
+            stable_time_out = min(3.0, remaining)
+            stable_settle = min(2.0, remaining)
             return self.wait_until(
                 lambda: self.is_main(esc=use_esc),
-                time_out=3.0,
-                settle_time=2.0,
+                time_out=stable_time_out,
+                settle_time=stable_settle,
                 raise_if_not_found=False,
             )
 

--- a/src/core/base_mixin/game_flow_mixin.py
+++ b/src/core/base_mixin/game_flow_mixin.py
@@ -242,6 +242,11 @@ class GameFlowMixin:
         """
         确保回到主界面（游戏世界）。
 
+        采用两段稳定检查确认主界面：
+        1. 第一段（疑似确认）：检测到一帧疑似主界面（Esc 图标）后，再确认一帧，
+           过滤加载/返回动画中的单帧闪屏误检；
+        2. 第二段（最终确认）：仅在第一段通过后执行，主界面状态须持续 2 秒。
+
         Args:
             esc: 是否在失败时执行返回键处理。
             time_out: 等待主界面的总超时时间。
@@ -258,21 +263,41 @@ class GameFlowMixin:
         start = self.active_time()
         observe_time = min(2.0, time_out)
 
+        def main_suspected(use_esc):
+            # 第一段稳定检查：疑似主界面（Esc）连续两帧出现才算通过
+            if not self.is_main(esc=use_esc):
+                return False
+            return self.is_main(esc=use_esc)
+
+        def main_stable(use_esc):
+            # 第二段稳定检查（最终确认）：仅在第一段通过后执行，状态须持续 2 秒
+            return self.wait_until(
+                lambda: self.is_main(esc=use_esc),
+                time_out=3.0,
+                settle_time=2.0,
+                raise_if_not_found=False,
+            )
+
         # Give loading and return animations a chance to finish before recovery input.
         result = self.wait_until(
-            lambda: self.is_main(esc=False),
+            lambda: main_suspected(False),
             time_out=observe_time,
-            settle_time=1.0,
+            settle_time=0,
             raise_if_not_found=False,
         )
+        if result:
+            result = main_stable(False)
+
         if not result and self.active_time() - start < time_out:
             self._next_main_recovery_time = self.active_time()
             result = self.wait_until(
-                lambda: self.is_main(esc=esc),
+                lambda: main_suspected(esc),
                 time_out=max(0.01, time_out - (self.active_time() - start)),
-                settle_time=1.0,
+                settle_time=0,
                 raise_if_not_found=False,
             )
+            if result:
+                result = main_stable(esc)
 
         if not result:
             raise Exception("Please start in game world and in team!")

--- a/tests/TestStateDrivenWaits.py
+++ b/tests/TestStateDrivenWaits.py
@@ -14,6 +14,7 @@ class _EnsureMainHarness(GameFlowMixin):
         self.wait_results = iter(wait_results)
         self.esc_checks = []
         self.sleeps = []
+        self.logs = []
         self.simulated_time = simulated_time or [1]
         self.time_index = 0
         self.wait_calls = []
@@ -45,6 +46,9 @@ class _EnsureMainHarness(GameFlowMixin):
 
     def sleep(self, timeout):
         self.sleeps.append(timeout)
+
+    def log_info(self, message):
+        self.logs.append(message)
 
 
 class _EnsureMapHarness(GameFlowMixin):
@@ -214,8 +218,8 @@ class TestStateDrivenWaits(unittest.TestCase):
 
         task.ensure_main()
 
-        # 第一段观察未过 → 恢复阶段疑似确认 + 第二段 2 秒稳定（最终确认）
-        self.assertEqual(task.esc_checks, [False, True, True])
+        # 第一段观察未过 → 恢复阶段疑似确认（按 ESC）+ 第二段 2 秒稳定（只观察不按键）
+        self.assertEqual(task.esc_checks, [False, True, False])
         self.assertEqual(task.sleeps, [])
 
     def test_ensure_main_natural_success_requires_two_stages(self):
@@ -227,13 +231,14 @@ class TestStateDrivenWaits(unittest.TestCase):
         self.assertEqual(task.esc_checks, [False, False])
         self.assertEqual(task.sleeps, [])
 
-    def test_ensure_main_stage_two_failure_enables_recovery(self):
+    def test_ensure_main_stage_two_failure_loops_recovery(self):
         task = _EnsureMainHarness([True, None, True, True])
 
         task.ensure_main()
 
-        # 第一段疑似通过但第二段 2 秒稳定失败 → 进入恢复阶段重新两段确认
-        self.assertEqual(task.esc_checks, [False, False, True, True])
+        # 观察阶段第一段疑似通过但第二段 2 秒稳定失败 → 进入恢复阶段重新两段确认（循环），
+        # 恢复阶段的第二段观察仍不按键（esc=False）
+        self.assertEqual(task.esc_checks, [False, False, True, False])
         self.assertEqual(task.sleeps, [])
 
     def test_ensure_main_short_timeout_caps_phase_b(self):
@@ -268,7 +273,7 @@ class TestStateDrivenWaits(unittest.TestCase):
         # 第一次相位A
         self.assertEqual(task.wait_calls[0]["time_out"], 1.0)
         # 恢复路径相位A，剩余时间接近0
-        self.assertLessEqual(task.wait_calls[1]["time_out"], 0.01)
+        self.assertAlmostEqual(task.wait_calls[1]["time_out"], 0.01, places=2)
 
     def test_ensure_main_very_short_timeout_does_not_hang(self):
         # 测试极短超时场景（time_out=0.5）：确保不会挂起或超出预算
@@ -284,6 +289,16 @@ class TestStateDrivenWaits(unittest.TestCase):
         self.assertLessEqual(task.wait_calls[1]["time_out"], 0.2)
         self.assertLessEqual(task.wait_calls[1]["settle_time"], 0.2)
         self.assertEqual(task.esc_checks, [False, False])
+
+    def test_ensure_main_recovery_stable_failure_keeps_looping(self):
+        task = _EnsureMainHarness([None, True, None, True, True])
+
+        task.ensure_main()
+
+        # 恢复阶段第二段再次失败后继续循环：疑似(ESC) → 稳定(不按键) → 成功
+        self.assertEqual(task.esc_checks, [False, True, False, True, False])
+        self.assertEqual(task.sleeps, [])
+        self.assertEqual(len([m for m in task.logs if "第二段稳定检查未通过" in m]), 1)
 
     def test_ensure_map_does_not_toggle_an_open_map(self):
         task = _EnsureMapHarness(in_map=True)

--- a/tests/TestStateDrivenWaits.py
+++ b/tests/TestStateDrivenWaits.py
@@ -10,10 +10,13 @@ from src.tasks.mixin.map_mixin import MapMixin
 
 
 class _EnsureMainHarness(GameFlowMixin):
-    def __init__(self, wait_results):
+    def __init__(self, wait_results, simulated_time=None):
         self.wait_results = iter(wait_results)
         self.esc_checks = []
         self.sleeps = []
+        self.simulated_time = simulated_time or [1]
+        self.time_index = 0
+        self.wait_calls = []
 
     def tr(self, message, **kwargs):
         return message
@@ -25,14 +28,19 @@ class _EnsureMainHarness(GameFlowMixin):
         pass
 
     def active_time(self):
-        return 1
+        if self.time_index < len(self.simulated_time):
+            return self.simulated_time[self.time_index]
+        return self.simulated_time[-1]
 
     def is_main(self, esc=False, need_active=True):
         self.esc_checks.append(esc)
         return False
 
     def wait_until(self, condition, **kwargs):
+        self.wait_calls.append(kwargs)
         condition()
+        if self.time_index + 1 < len(self.simulated_time):
+            self.time_index += 1
         return next(self.wait_results)
 
     def sleep(self, timeout):
@@ -227,6 +235,55 @@ class TestStateDrivenWaits(unittest.TestCase):
         # 第一段疑似通过但第二段 2 秒稳定失败 → 进入恢复阶段重新两段确认
         self.assertEqual(task.esc_checks, [False, False, True, True])
         self.assertEqual(task.sleeps, [])
+
+    def test_ensure_main_short_timeout_caps_phase_b(self):
+        # 测试短超时场景（time_out=1.0）：相位B的超时时间应受限于剩余时间
+        # 模拟时间：start=0, 相位A后=0.5, 相位B调用时剩余0.5秒
+        task = _EnsureMainHarness([True, True], simulated_time=[0, 0.5, 0.5])
+
+        task.ensure_main(time_out=1.0)
+
+        # 验证第二个 wait_until (相位B) 使用了受限的超时时间
+        self.assertEqual(len(task.wait_calls), 2)
+        # 相位A: time_out=min(2.0, 1.0)=1.0
+        self.assertEqual(task.wait_calls[0]["time_out"], 1.0)
+        # 相位B: time_out=min(3.0, 0.5)=0.5, settle_time=min(2.0, 0.5)=0.5
+        self.assertLessEqual(task.wait_calls[1]["time_out"], 0.5)
+        self.assertLessEqual(task.wait_calls[1]["settle_time"], 0.5)
+        self.assertEqual(task.esc_checks, [False, False])
+
+    def test_ensure_main_near_deadline_skips_phase_b_when_no_time_remains(self):
+        # 测试接近截止时间场景：相位A消耗大部分时间，相位B无剩余时间则返回False
+        # 模拟时间：start=0, 相位A后=0.99, 剩余0.01秒
+        # 当相位A返回False时，应尝试恢复路径
+        task = _EnsureMainHarness([None, True, None], simulated_time=[0, 0.99, 1.0, 1.0])
+
+        with self.assertRaises(Exception) as context:
+            task.ensure_main(time_out=1.0)
+
+        # 验证抛出正确的异常
+        self.assertEqual(str(context.exception), "Please start in game world and in team!")
+        # 相位A失败，进入恢复路径的相位A，相位B因剩余时间<=0而返回False
+        self.assertEqual(len(task.wait_calls), 2)
+        # 第一次相位A
+        self.assertEqual(task.wait_calls[0]["time_out"], 1.0)
+        # 恢复路径相位A，剩余时间接近0
+        self.assertLessEqual(task.wait_calls[1]["time_out"], 0.01)
+
+    def test_ensure_main_very_short_timeout_does_not_hang(self):
+        # 测试极短超时场景（time_out=0.5）：确保不会挂起或超出预算
+        # 模拟时间：start=0, 相位A后=0.3, 相位B有0.2秒剩余
+        task = _EnsureMainHarness([True, True], simulated_time=[0, 0.3, 0.3])
+
+        task.ensure_main(time_out=0.5)
+
+        # 验证相位B的超时时间被正确限制
+        self.assertEqual(len(task.wait_calls), 2)
+        self.assertEqual(task.wait_calls[0]["time_out"], 0.5)
+        # 相位B: 剩余0.2秒，time_out和settle_time都应<=0.2
+        self.assertLessEqual(task.wait_calls[1]["time_out"], 0.2)
+        self.assertLessEqual(task.wait_calls[1]["settle_time"], 0.2)
+        self.assertEqual(task.esc_checks, [False, False])
 
     def test_ensure_map_does_not_toggle_an_open_map(self):
         task = _EnsureMapHarness(in_map=True)

--- a/tests/TestStateDrivenWaits.py
+++ b/tests/TestStateDrivenWaits.py
@@ -202,19 +202,30 @@ class _TaskMapHarness:
 
 class TestStateDrivenWaits(unittest.TestCase):
     def test_ensure_main_observes_before_enabling_recovery(self):
-        task = _EnsureMainHarness([None, True])
+        task = _EnsureMainHarness([None, True, True])
 
         task.ensure_main()
 
-        self.assertEqual(task.esc_checks, [False, True])
+        # 第一段观察未过 → 恢复阶段疑似确认 + 第二段 2 秒稳定（最终确认）
+        self.assertEqual(task.esc_checks, [False, True, True])
         self.assertEqual(task.sleeps, [])
 
-    def test_ensure_main_natural_success_never_enables_recovery(self):
-        task = _EnsureMainHarness([True])
+    def test_ensure_main_natural_success_requires_two_stages(self):
+        task = _EnsureMainHarness([True, True])
 
         task.ensure_main()
 
-        self.assertEqual(task.esc_checks, [False])
+        # 第一段疑似通过后仍须经过第二段稳定检查才最终确认，未进入恢复阶段
+        self.assertEqual(task.esc_checks, [False, False])
+        self.assertEqual(task.sleeps, [])
+
+    def test_ensure_main_stage_two_failure_enables_recovery(self):
+        task = _EnsureMainHarness([True, None, True, True])
+
+        task.ensure_main()
+
+        # 第一段疑似通过但第二段 2 秒稳定失败 → 进入恢复阶段重新两段确认
+        self.assertEqual(task.esc_checks, [False, False, True, True])
         self.assertEqual(task.sleeps, [])
 
     def test_ensure_map_does_not_toggle_an_open_map(self):


### PR DESCRIPTION
### 问题

`ensure_main` 目前只有一段稳定检查（`wait_until` 的 `settle_time=1.0`）：只要 `is_main` 返回 True 并维持 1 秒即视为回到主界面。加载/返回动画期间可能出现单帧 Esc 图标误检，1 秒稳定窗口不足以过滤这类闪屏。

### 修复

`ensure_main` 改为两段稳定检查：

1. **第一段（疑似确认）**：检测到一帧疑似主界面（Esc 图标）后，立即再确认一帧，连续两帧才算通过，过滤单帧闪屏/动画误检；
2. **第二段（最终确认）**：仅在第一段通过后执行，主界面状态须持续 **2 秒**（`settle_time=2.0`）才最终确认。

观察阶段与恢复阶段（按 ESC 返回）均采用同一两段结构。

### 验证

- `uv run python -m unittest discover -s tests`：292 个测试全部通过
- 新增测试：自然成功须经过两段检查（`[False, False]`）、第二段稳定失败会进入恢复阶段重新两段确认（`[False, False, True, True]`）

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug 修复**
  - 优化主界面检查流程，通过分阶段确认界面状态，并遵循整体超时限制。
  - 改进返回操作后的恢复流程，在剩余时间内持续尝试确认。
  - 稳定检查失败后继续等待，最终确认阶段停止返回操作。
  - 改善极短超时及无剩余时间场景下的处理，提升界面切换稳定性。

- **测试**
  - 增加两阶段确认、超时限制、恢复循环及边界场景的测试覆盖。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->