### PR TITLE
fix: 真正卖出货物后直接 ensure_main 结束本区域建设，不走 safe_back 逐层返回

### DIFF
--- a/src/tasks/daily/daily_regional_runner.py
+++ b/src/tasks/daily/daily_regional_runner.py
@@ -37,13 +37,19 @@ class DailyRegionalRunner:
                 # 因此用 _buy_ran 标记，回调未执行时单独补一次买物资。
                 # 任一步骤失败均只记录日志，继续处理下一地区。
                 self._buy_ran = False
-                trade_ok = self._task.daily_trade.buy_sell(
+                trade_ok, sold_any = self._task.daily_trade.buy_sell(
                     target_areas=[area],
                     keep_area_context=True,
                     after_buy=self._buy_staple_after_trade if enabled_buy else None,
                 )
                 if not trade_ok:
                     self.log_info(self.tr("买卖货失败: {area}").format(area=self.tr(area)))
+                if sold_any:
+                    # 真正卖出过货物：角色已在好友船/野外，界面远离地区建设总览，
+                    # 逐层返回难以退回。直接回主界面结束本区域建设，继续下一区域。
+                    self._task.ensure_main()
+                    self.log_info(self.tr("已实际卖出货物，结束{area}地区建设").format(area=self.tr(area)))
+                    continue
                 if enabled_buy and not self._buy_ran:
                     self.log_info("买卖货未执行买物资回调，单独执行买物资")
                     self._buy_staple_in_area(area)

--- a/src/tasks/daily/daily_trade_mixin.py
+++ b/src/tasks/daily/daily_trade_mixin.py
@@ -301,7 +301,14 @@ class DailyTradeFeature:
         return result
 
     def buy_sell(self, target_areas=None, keep_area_context=False, after_buy=None):
+        """买卖货主流程。
+
+        Returns:
+            tuple[bool, bool]: (是否未发生导航失败, 是否真正卖出过货物——
+                仅当加号成功、出售确认按钮点击成功且弹窗关闭后才为 True)。
+        """
         navigation_failed = False
+        sold_any = False
         for area in target_areas or areas_list:
             if not self.config.get(area, False):
                 self.log_info(self.tr("跳过{area}，因为配置中未启用").format(area=self.tr(area)))
@@ -367,7 +374,7 @@ class DailyTradeFeature:
                             self.log_info(
                                 "等待返回 '地区建设' 界面超时，结束买卖货任务"
                             )
-                            return False
+                            return False, sold_any
                         self.back()
                     self.click(buy_good.name_box)
                     self.wait_ui_stable(refresh_interval=1)
@@ -411,7 +418,7 @@ class DailyTradeFeature:
                 ):
                     if self.active_time() > back_to_area_deadline:
                         self.log_info("等待返回 '地区建设' 界面超时，结束买卖货任务")
-                        return False
+                        return False, sold_any
                     self.back()
                 if not (self.wait_click_ocr(match=re.compile(sell_good.name_box.name[-3:]), log=True) or
                         self.wait_click_ocr(match=re.compile(sell_good.good_name[:3]), log=True)):
@@ -444,7 +451,7 @@ class DailyTradeFeature:
                     continue
                 if not self.ensure_in_friend_boat():
                     self.log_info("未进入好友船")
-                    return False
+                    return False, sold_any
                 self.navigate_to_friend_exchange()
                 self.wait_click_ocr(match=get_world_map_matcher(self.lang, area), box=self.box.top)
                 if not (self.wait_click_ocr(match=re.compile(sell_good.name_box.name[-3:])) or
@@ -453,12 +460,15 @@ class DailyTradeFeature:
                     continue
                 self.wait_ui_stable(refresh_interval=1)
                 if self.plus_max():
-                    self.wait_click_ocr(
+                    # 仅当出售确认按钮真正点击成功且弹窗关闭，才算真正卖出
+                    sold_confirmed = self.wait_click_ocr(
                         match=self.lang.daily_trade_mixin.k_b84e4cb0,
                         box=self.box.bottom_right,
                     )
                     self.wait_pop_up()
+                    if sold_confirmed:
+                        sold_any = True
                 else:
                     self.log_info("未找到加号按钮，无法出售")
 
-        return not navigation_failed
+        return not navigation_failed, sold_any

--- a/tests/TestDailyRegionalRunner.py
+++ b/tests/TestDailyRegionalRunner.py
@@ -6,12 +6,14 @@ from unittest.mock import Mock, patch
 from src.tasks.daily.daily_regional_runner import DailyRegionalRunner
 
 
-def _make_task(config_options, buy_sell_result=True, after_buy_called=True,
-               exchange_result=True, buy_staple_result=True, to_model_area_result=True):
+def _make_task(config_options, buy_sell_result=True, sold_result=False,
+               after_buy_called=True, exchange_result=True, buy_staple_result=True,
+               to_model_area_result=True):
     """构造一个带 mock 的 task，用于 DailyRegionalRunner 分支测试。
 
     after_buy_called: buy_sell 是否真的触发 after_buy 回调
                       （为 False 时模拟地区未启用/未找到货物/缺买卖价跳过的场景）
+    sold_result: buy_sell 是否报告「真正卖出过货物」。
     """
     task = SimpleNamespace()
     task.config = SimpleNamespace(get=lambda key, default=None: config_options)
@@ -19,13 +21,14 @@ def _make_task(config_options, buy_sell_result=True, after_buy_called=True,
     task.daily_buy = SimpleNamespace(buy_staple_goods=Mock(return_value=buy_staple_result))
     task.to_model_area = Mock(return_value=to_model_area_result)
     task.safe_back = Mock()
+    task.ensure_main = Mock()
     task.log_info = Mock()
     task.tr = lambda message, **kwargs: message
 
     def buy_sell_impl(target_areas=None, keep_area_context=False, after_buy=None):
         if after_buy is not None and after_buy_called and target_areas:
             after_buy(target_areas[0])
-        return buy_sell_result
+        return buy_sell_result, sold_result
 
     task.daily_trade = SimpleNamespace(buy_sell=Mock(side_effect=buy_sell_impl))
     return task
@@ -88,6 +91,29 @@ class TestDailyRegionalRunner(unittest.TestCase):
         self.assertTrue(result)
         logged = " ".join(call.args[0] for call in task.log_info.call_args_list)
         self.assertIn("买卖货失败", logged)
+
+    # ── 真正卖出过货物 → 直接回主界面、跳过 safe_back、继续下一区域 ──
+    def test_trade_sold_ensure_main_skips_safe_back_and_continues(self):
+        task = _make_task(["买卖货"], sold_result=True)
+        result = self.run_runner(task)
+
+        self.assertTrue(result)
+        # 每个区域卖出后都直接 ensure_main，不再走 safe_back 逐层返回
+        self.assertEqual(task.ensure_main.call_count, 2)
+        task.safe_back.assert_not_called()
+        # 继续处理下一区域
+        self.assertEqual(task.daily_trade.buy_sell.call_count, 2)
+        logged = " ".join(call.args[0] for call in task.log_info.call_args_list)
+        self.assertIn("已实际卖出货物", logged)
+
+    # ── 未卖出时仍走原 safe_back 返回路径，不调用 ensure_main ──
+    def test_trade_not_sold_keeps_safe_back_path(self):
+        task = _make_task(["买卖货"], sold_result=False)
+        result = self.run_runner(task)
+
+        self.assertTrue(result)
+        task.ensure_main.assert_not_called()
+        self.assertEqual(task.safe_back.call_count, 2)
 
     # ── 据点兑换失败 → 记录日志并继续下一地区 ──
     def test_outpost_failure_logs_and_continues(self):


### PR DESCRIPTION
### 问题

地区建设循环每处理完一个地区后调用 `safe_back(feature=transaction_overview, once_time_out=3)` 逐层按 ESC 退回「地区建设」总览（`daily_regional_runner.py:54`）。

但当**真正卖出过货物**时，角色已导航到好友船/野外（`daily_trade_mixin.buy_sell` 的卖出分支），界面远离地区建设总览，一次 ESC 只能退一层，30 秒内退不回去，日志持续刷「safe_back 观察超时，发送返回键」。

### 修复

- `daily_trade_mixin.buy_sell` 返回值改为 `(是否导航未失败, 是否真正卖出)`：
  - `sold_any` 仅在**加号成功 + 出售确认按钮真正点击成功 + 弹窗关闭**后才置 True（`wait_click_ocr` 返回值校验），区分「真正卖了」与「进入卖出流程但未卖成」；
- `daily_regional_runner` 解包新返回值：`sold_any` 为 True 时**直接 `ensure_main()` 回主界面**、跳过 safe_back、结束**本区域**建设并继续下一个区域；未卖出时保持原 safe_back 路径不变。

### 验证

- `uv run python -m unittest discover -s tests`：293 个测试全部通过
- 新增测试：卖出后 `ensure_main` 每区域调用、`safe_back` 零调用、继续下一区域；未卖出时 `ensure_main` 不调用、safe_back 每区域一次

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **功能优化**
  - 优化每日区域交易流程：成功卖出货物后自动返回主界面，并直接继续处理下一区域。
  - 更准确地区分交易成功与实际卖出货物两种状态。
  - 未实际卖出货物时，继续沿用原有的返回与后续处理流程。

- **问题修复**
  - 改进导航超时或无法进入好友船时的交易状态处理，避免流程判断不准确。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->