### PR TITLE
fix: 触发 ensure_main 返回的条件改为已点击前往并到达好友帝江号

### DIFF
--- a/src/tasks/daily/daily_regional_runner.py
+++ b/src/tasks/daily/daily_regional_runner.py
@@ -37,18 +37,18 @@ class DailyRegionalRunner:
                 # 因此用 _buy_ran 标记，回调未执行时单独补一次买物资。
                 # 任一步骤失败均只记录日志，继续处理下一地区。
                 self._buy_ran = False
-                trade_ok, sold_any = self._task.daily_trade.buy_sell(
+                trade_ok, went_friend_boat = self._task.daily_trade.buy_sell(
                     target_areas=[area],
                     keep_area_context=True,
                     after_buy=self._buy_staple_after_trade if enabled_buy else None,
                 )
                 if not trade_ok:
                     self.log_info(self.tr("买卖货失败: {area}").format(area=self.tr(area)))
-                if sold_any:
-                    # 真正卖出过货物：角色已在好友船/野外，界面远离地区建设总览，
+                if went_friend_boat:
+                    # 已前往好友帝江号：角色在野外，界面远离地区建设总览，
                     # 逐层返回难以退回。直接回主界面结束本区域建设，继续下一区域。
                     self._task.ensure_main()
-                    self.log_info(self.tr("已实际卖出货物，结束{area}地区建设").format(area=self.tr(area)))
+                    self.log_info(self.tr("已前往好友帝江号，直接回主界面结束{area}地区建设").format(area=self.tr(area)))
                     continue
                 if enabled_buy and not self._buy_ran:
                     self.log_info("买卖货未执行买物资回调，单独执行买物资")

--- a/src/tasks/daily/daily_trade_mixin.py
+++ b/src/tasks/daily/daily_trade_mixin.py
@@ -304,11 +304,11 @@ class DailyTradeFeature:
         """买卖货主流程。
 
         Returns:
-            tuple[bool, bool]: (是否未发生导航失败, 是否真正卖出过货物——
-                仅当加号成功、出售确认按钮点击成功且弹窗关闭后才为 True)。
+            tuple[bool, bool]: (是否未发生导航失败, 是否已前往好友帝江号——
+                仅当「前往」按钮真正点击成功且到达好友船后才为 True)。
         """
         navigation_failed = False
-        sold_any = False
+        went_friend_boat = False
         for area in target_areas or areas_list:
             if not self.config.get(area, False):
                 self.log_info(self.tr("跳过{area}，因为配置中未启用").format(area=self.tr(area)))
@@ -374,7 +374,7 @@ class DailyTradeFeature:
                             self.log_info(
                                 "等待返回 '地区建设' 界面超时，结束买卖货任务"
                             )
-                            return False, sold_any
+                            return False, went_friend_boat
                         self.back()
                     self.click(buy_good.name_box)
                     self.wait_ui_stable(refresh_interval=1)
@@ -418,7 +418,7 @@ class DailyTradeFeature:
                 ):
                     if self.active_time() > back_to_area_deadline:
                         self.log_info("等待返回 '地区建设' 界面超时，结束买卖货任务")
-                        return False, sold_any
+                        return False, went_friend_boat
                     self.back()
                 if not (self.wait_click_ocr(match=re.compile(sell_good.name_box.name[-3:]), log=True) or
                         self.wait_click_ocr(match=re.compile(sell_good.good_name[:3]), log=True)):
@@ -451,7 +451,10 @@ class DailyTradeFeature:
                     continue
                 if not self.ensure_in_friend_boat():
                     self.log_info("未进入好友船")
-                    return False, sold_any
+                    return False, went_friend_boat
+                # 已真正点击「前往」并到达好友帝江号：角色在野外，之后无论卖出是否
+                # 完成都只能 ensure_main 返回主界面（safe_back 逐层返回无法退回地区建设）
+                went_friend_boat = True
                 self.navigate_to_friend_exchange()
                 self.wait_click_ocr(match=get_world_map_matcher(self.lang, area), box=self.box.top)
                 if not (self.wait_click_ocr(match=re.compile(sell_good.name_box.name[-3:])) or
@@ -460,15 +463,12 @@ class DailyTradeFeature:
                     continue
                 self.wait_ui_stable(refresh_interval=1)
                 if self.plus_max():
-                    # 仅当出售确认按钮真正点击成功且弹窗关闭，才算真正卖出
-                    sold_confirmed = self.wait_click_ocr(
+                    self.wait_click_ocr(
                         match=self.lang.daily_trade_mixin.k_b84e4cb0,
                         box=self.box.bottom_right,
                     )
                     self.wait_pop_up()
-                    if sold_confirmed:
-                        sold_any = True
                 else:
                     self.log_info("未找到加号按钮，无法出售")
 
-        return not navigation_failed, sold_any
+        return not navigation_failed, went_friend_boat

--- a/tests/TestDailyRegionalRunner.py
+++ b/tests/TestDailyRegionalRunner.py
@@ -6,14 +6,14 @@ from unittest.mock import Mock, patch
 from src.tasks.daily.daily_regional_runner import DailyRegionalRunner
 
 
-def _make_task(config_options, buy_sell_result=True, sold_result=False,
+def _make_task(config_options, buy_sell_result=True, went_friend_boat_result=False,
                after_buy_called=True, exchange_result=True, buy_staple_result=True,
                to_model_area_result=True):
     """构造一个带 mock 的 task，用于 DailyRegionalRunner 分支测试。
 
     after_buy_called: buy_sell 是否真的触发 after_buy 回调
                       （为 False 时模拟地区未启用/未找到货物/缺买卖价跳过的场景）
-    sold_result: buy_sell 是否报告「真正卖出过货物」。
+    went_friend_boat_result: buy_sell 是否报告「已前往好友帝江号」。
     """
     task = SimpleNamespace()
     task.config = SimpleNamespace(get=lambda key, default=None: config_options)
@@ -28,7 +28,7 @@ def _make_task(config_options, buy_sell_result=True, sold_result=False,
     def buy_sell_impl(target_areas=None, keep_area_context=False, after_buy=None):
         if after_buy is not None and after_buy_called and target_areas:
             after_buy(target_areas[0])
-        return buy_sell_result, sold_result
+        return buy_sell_result, went_friend_boat_result
 
     task.daily_trade = SimpleNamespace(buy_sell=Mock(side_effect=buy_sell_impl))
     return task
@@ -92,23 +92,23 @@ class TestDailyRegionalRunner(unittest.TestCase):
         logged = " ".join(call.args[0] for call in task.log_info.call_args_list)
         self.assertIn("买卖货失败", logged)
 
-    # ── 真正卖出过货物 → 直接回主界面、跳过 safe_back、继续下一区域 ──
-    def test_trade_sold_ensure_main_skips_safe_back_and_continues(self):
-        task = _make_task(["买卖货"], sold_result=True)
+    # ── 已前往好友帝江号 → 直接回主界面、跳过 safe_back、继续下一区域 ──
+    def test_trade_went_friend_boat_ensure_main_skips_safe_back_and_continues(self):
+        task = _make_task(["买卖货"], went_friend_boat_result=True)
         result = self.run_runner(task)
 
         self.assertTrue(result)
-        # 每个区域卖出后都直接 ensure_main，不再走 safe_back 逐层返回
+        # 每个区域前往好友船后都直接 ensure_main，不再走 safe_back 逐层返回
         self.assertEqual(task.ensure_main.call_count, 2)
         task.safe_back.assert_not_called()
         # 继续处理下一区域
         self.assertEqual(task.daily_trade.buy_sell.call_count, 2)
         logged = " ".join(call.args[0] for call in task.log_info.call_args_list)
-        self.assertIn("已实际卖出货物", logged)
+        self.assertIn("已前往好友帝江号", logged)
 
-    # ── 未卖出时仍走原 safe_back 返回路径，不调用 ensure_main ──
-    def test_trade_not_sold_keeps_safe_back_path(self):
-        task = _make_task(["买卖货"], sold_result=False)
+    # ── 未前往好友船时仍走原 safe_back 返回路径，不调用 ensure_main ──
+    def test_trade_not_went_friend_boat_keeps_safe_back_path(self):
+        task = _make_task(["买卖货"], went_friend_boat_result=False)
         result = self.run_runner(task)
 
         self.assertTrue(result)


### PR DESCRIPTION
### 问题

上一版（#263）把「直接 ensure_main 返回」的触发条件定为「真正卖出货物」。但正确语义是：只要**真正点击了「前往」按钮并到达好友帝江号**，角色就处于野外，之后无论卖出是否完成，safe_back 逐层按 ESC 都无法退回「地区建设」总览，只能 ensure_main 返回主界面。

### 修复

- `daily_trade_mixin.buy_sell` 返回值第二项由「是否真正卖出」改为「是否已前往好友帝江号」：仅在「前往」按钮真正点击成功（`wait_click_ocr` 命中）且 `ensure_in_friend_boat()` 检查通过后置 True；出售确认逻辑恢复原样（不再依赖卖出完成）
- `daily_regional_runner`：该标志为 True 时直接 `ensure_main()` 回主界面、跳过 safe_back、结束本区域建设并继续下一区域；否则保持原路径

### 验证

- `uv run python -m unittest discover -s tests`：293 个测试全部通过
- 新增测试：前往好友船后 `ensure_main` 每区域调用、`safe_back` 零调用、继续下一区域；未前往时 `ensure_main` 不调用、safe_back 每区域一次

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **功能优化**
  * 优化每日区域贸易流程：前往好友帝江号后将直接返回主界面，并结束当前区域建设，继续处理下一区域。
  * 优化导航状态判断，只有成功进入好友帝江号后才更新状态。
  * 保留出售确认和弹窗关闭流程，不再以出售结果影响后续导航处理。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->