### PR TITLE
fix: 调整 settle_time 为 2 秒以确保按钮稳定显示

### DIFF
--- a/src/tasks/daily/daily_battle_mixin.py
+++ b/src/tasks/daily/daily_battle_mixin.py
@@ -868,7 +868,7 @@ class DailyBattleFeature:
                     match=re.compile(click_key),
                     box=self.box.bottom_right,
                     time_out=3,
-                    settle_time=1.0,
+                    settle_time=2,
                 )
                 if not stable:
                     self.log_info(f"『{click_key}』按钮未稳定显示，跳过直接点击，继续寻路")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 延长奖励按钮稳定显示的等待时间，提升奖励领取操作的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->