### PR TITLE
test: 移除低价值测试用例

### DIFF
--- a/src/tasks/daily/misc/daily_outpost_mixin.py
+++ b/src/tasks/daily/misc/daily_outpost_mixin.py
@@ -196,30 +196,6 @@ class DailyOutpostMixin:
 
         self.log_info(f"{outpost_name} 兑换操作完成")
 
-    def test_ocr_full(self):
-        self.next_frame()
-        self.ocr(log=True)
-
-    def test_ocr(self):
-        box1 = self.box_of_screen(1749 / 1920, 107 / 1080, 1789 / 1920, 134 / 1080)
-        box2 = self.box_of_screen(
-            (1749 + (1832 - 1750)) / 1920, 107 / 1080, (1789 + (1832 - 1750)) / 1920, 134 / 1080
-        )
-        self.wait_click_ocr(
-            match=re.compile(r"^\d+/5$"),
-            after_sleep=2,
-            time_out=2,
-            box=box1,
-            log=True,
-        )
-        self.wait_click_ocr(
-            match=re.compile(r"^\d+/5$"),
-            after_sleep=2,
-            time_out=2,
-            box=box2,
-            log=True,
-        )
-
     def exchange_outpost_goods(self, target_areas=None, keep_area_context=False):
         self.info_set("current_task", "exchange_outpost_goods")
         self.log_info("开始据点兑换任务")

--- a/src/tasks/trigger/AutoPickTask.py
+++ b/src/tasks/trigger/AutoPickTask.py
@@ -1,5 +1,3 @@
-import cv2
-import numpy as np
 from ok import Logger, TriggerTask
 
 from src.core.BaseEfTask import BaseEfTask
@@ -88,19 +86,3 @@ white_color = {
     'g': (230, 255),
     'b': (230, 255)
 }
-
-gray_color = {
-    'r': (40, 90),
-    'g': (40, 90),
-    'b': (40, 90),
-}
-
-
-def is_mostly_grayscale(frame, threshold=10):
-    b, g, r = cv2.split(frame)
-    diff_rg = cv2.absdiff(r, g)
-    diff_gb = cv2.absdiff(g, b)
-    diff_br = cv2.absdiff(b, r)
-    gray_mask = (diff_rg < threshold) & (diff_gb < threshold) & (diff_br < threshold)
-    gray_percentage = (np.sum(gray_mask) / frame.size * 3)
-    return gray_percentage

--- a/tests/TestAccountBattleConfig.py
+++ b/tests/TestAccountBattleConfig.py
@@ -298,28 +298,6 @@ class TestAccountConfigRules(unittest.TestCase):
         tab.current_virtual_config["普通配置"] = 5
         self.assertTrue(tab._has_current_task_changes())
 
-    def test_tasks_hide_only_non_account_execution_controls(self):
-        self.assertTrue({
-            "发生异常时终止游戏",
-            "仅退出游戏",
-            "自动打开汇总文件",
-            "Exit After Task",
-            "重复测试的次数",
-        }.issubset(DailyTask.account_config_blacklist))
-        self.assertTrue({
-            "选择测试对象",
-            "仅接取",
-            "仅送货",
-            "完整循环测试区域",
-            "发生异常时终止游戏",
-            "Exit After Task",
-        }.issubset(DeliveryTask.account_config_blacklist))
-
-        self.assertNotIn("配置选择", DailyTask.account_config_blacklist)
-        self.assertNotIn("⭐执行外部命令", DailyTask.account_config_blacklist)
-        self.assertNotIn("外部命令", DailyTask.account_config_blacklist)
-        self.assertNotIn("通向武陵城送货点", DeliveryTask.account_config_blacklist)
-
 class TestBattleConfigOverrides(unittest.TestCase):
     def make_battle_task(self, config):
         task = object.__new__(BattleMixin)
@@ -361,11 +339,6 @@ class TestBattleConfigOverrides(unittest.TestCase):
 
         self.assertEqual(task.get_battle_config("启动技能点数"), 2)
 
-    def test_global_battle_config_is_fallback_for_task(self):
-        task = self.make_battle_task({})
-
-        self.assertEqual(task.get_battle_config("启动技能点数"), 2)
-
 
 class TestUseIndependentParsing(unittest.TestCase):
     """测试「使用独立配置」值的解析和回退行为"""
@@ -374,14 +347,6 @@ class TestUseIndependentParsing(unittest.TestCase):
         task = object.__new__(BattleMixin)
         task.log_debug = lambda msg: None
         return task
-
-    def test_boolean_true_returns_true(self):
-        task = self.make_task()
-        self.assertTrue(task._parse_use_independent(True))
-
-    def test_boolean_false_returns_false(self):
-        task = self.make_task()
-        self.assertFalse(task._parse_use_independent(False))
 
     def test_legacy_dropdown_use_independent_string(self):
         """旧下拉框值「使用独立配置」应解析为 True"""
@@ -407,35 +372,12 @@ class TestUseIndependentParsing(unittest.TestCase):
             with self.subTest(value=value):
                 self.assertFalse(task._parse_use_independent(value))
 
-    def test_empty_string_returns_false(self):
-        """空字符串应解析为 False"""
-        task = self.make_task()
-        self.assertFalse(task._parse_use_independent(""))
-
-    def test_whitespace_string_returns_false(self):
-        """空白字符串应解析为 False"""
-        task = self.make_task()
-        self.assertFalse(task._parse_use_independent("   "))
-
-    def test_none_returns_false(self):
-        """None 应回退到 False"""
-        task = self.make_task()
-        self.assertFalse(task._parse_use_independent(None))
-
     def test_invalid_string_returns_false(self):
         """无效字符串应回退到 False（默认值）"""
         task = self.make_task()
         for value in ["invalid", "random_text", "2", "maybe"]:
             with self.subTest(value=value):
                 self.assertFalse(task._parse_use_independent(value))
-
-    def test_invalid_types_return_false(self):
-        """非布尔/字符串类型应回退到 False"""
-        task = self.make_task()
-        for value in [123, 1.5, [], {}, object()]:
-            with self.subTest(value=type(value).__name__):
-                self.assertFalse(task._parse_use_independent(value))
-
 
 class TestUseIndependentBattleConfigSelection(unittest.TestCase):
     """测试不同「使用独立配置」值下的战斗配置选择行为"""
@@ -458,31 +400,6 @@ class TestUseIndependentBattleConfigSelection(unittest.TestCase):
     def test_legacy_string_use_global_selects_global_config(self):
         """旧字符串值「使用全局配置」应选择全局配置"""
         task = self.make_task_with_value("使用全局配置")
-        self.assertEqual(task.get_battle_config("启动技能点数"), 2)
-
-    def test_string_true_selects_task_config(self):
-        """字符串 "true" 应选择任务配置"""
-        task = self.make_task_with_value("true")
-        self.assertEqual(task.get_battle_config("启动技能点数"), 3)
-
-    def test_string_false_selects_global_config(self):
-        """字符串 "false" 应选择全局配置"""
-        task = self.make_task_with_value("false")
-        self.assertEqual(task.get_battle_config("启动技能点数"), 2)
-
-    def test_string_1_selects_task_config(self):
-        """字符串 "1" 应选择任务配置"""
-        task = self.make_task_with_value("1")
-        self.assertEqual(task.get_battle_config("启动技能点数"), 3)
-
-    def test_string_0_selects_global_config(self):
-        """字符串 "0" 应选择全局配置"""
-        task = self.make_task_with_value("0")
-        self.assertEqual(task.get_battle_config("启动技能点数"), 2)
-
-    def test_invalid_string_selects_global_config(self):
-        """无效字符串应回退到全局配置（默认行为）"""
-        task = self.make_task_with_value("invalid_value")
         self.assertEqual(task.get_battle_config("启动技能点数"), 2)
 
 if __name__ == "__main__":

--- a/tests/TestAutoPick.py
+++ b/tests/TestAutoPick.py
@@ -1,10 +1,7 @@
 import unittest
 
 from src.tasks.trigger.auto_pick_rules import (
-    BLACK_LIST,
-    CFG_SKIP_PRODUCIBLE,
     PICKABLE_PLANT_VARIANTS,
-    PRODUCIBLE_PLANTS,
     WHITE_LIST,
     should_skip_pick,
 )
@@ -12,10 +9,6 @@ from src.tasks.trigger.auto_pick_rules import (
 
 class TestAutoPickRules(unittest.TestCase):
     def test_producible_plants_are_skipped_by_default(self):
-        self.assertEqual(
-            PRODUCIBLE_PLANTS,
-            {'琼叶参', '金石稻', '芽针', '锦草', '苦叶椒', '砂叶', '灰芦麦', '柑实', '荞花', '酮化灌木'},
-        )
         self.assertTrue(should_skip_pick('荞花'))
         self.assertTrue(should_skip_pick('获得锦草 x3'))
         self.assertTrue(should_skip_pick('酮化灌木'))
@@ -25,10 +18,6 @@ class TestAutoPickRules(unittest.TestCase):
         self.assertTrue(should_skip_pick('激活箱子'))
 
     def test_special_plant_variants_are_not_skipped_by_default(self):
-        self.assertEqual(
-            PICKABLE_PLANT_VARIANTS,
-            {'荆刺芽针', '蓬茸锦草', '黯银柑实', '映火荞花'},
-        )
         for item_name in PICKABLE_PLANT_VARIANTS:
             self.assertFalse(should_skip_pick(item_name))
 
@@ -56,12 +45,7 @@ class TestAutoPickRules(unittest.TestCase):
                 f'{text} 应被子串匹配到白名单',
             )
 
-    def test_black_list_entries_are_not_in_whitelist(self):
-        self.assertTrue(BLACK_LIST)
-        self.assertFalse(BLACK_LIST & WHITE_LIST)
 
-    def test_config_key_is_registered(self):
-        self.assertEqual(CFG_SKIP_PRODUCIBLE, '屏蔽可量产植物')
 
 
 if __name__ == '__main__':

--- a/tests/TestConditionalRotationGui.py
+++ b/tests/TestConditionalRotationGui.py
@@ -6,72 +6,7 @@ from unittest.mock import patch
 
 from PySide6.QtWidgets import QApplication, QWidget
 
-from src.gui.ConditionalRotationPanel import (
-    _ConditionDisplayCard, _ConditionEditDialog, _ConditionEditor,
-    _ActionListEditor, _fmt_cond, _fmt_actions, _fmt_action, _fmt_atom,
-)
-from src.core.rotation_ast import normalize_ast
-
-
-class TestFormatters(unittest.TestCase):
-    """友好名格式化函数测试。"""
-
-    @patch("src.gui.ConditionalRotationPanel._tr", side_effect=lambda x: x)
-    def test_fmt_action(self, _):
-        self.assertEqual(_fmt_action("1"), "战技 1")
-        self.assertEqual(_fmt_action("e"), "连携技")
-        self.assertEqual(_fmt_action("ult_2"), "终结技 2")
-        self.assertEqual(_fmt_action("sleep_5"), "等待5秒")
-        self.assertEqual(_fmt_action("normal_3"), "普通3秒")
-
-    @patch("src.gui.ConditionalRotationPanel._tr", side_effect=lambda x: x)
-    def test_fmt_atom(self, _):
-        self.assertEqual(_fmt_atom("ult1"), "终结技 1 可用")
-        self.assertEqual(_fmt_atom("link"), "连携技可用")
-        self.assertEqual(_fmt_atom("skill>=2"), "技力≥2")
-
-    @patch("src.gui.ConditionalRotationPanel._tr", side_effect=lambda x: x)
-    def test_fmt_cond_atom(self, _):
-        typ, desc = _fmt_cond("link")
-        self.assertEqual(typ, "满足条件")
-        self.assertEqual(desc, "连携技可用")
-
-    @patch("src.gui.ConditionalRotationPanel._tr", side_effect=lambda x: x)
-    def test_fmt_cond_all_any(self, _):
-        typ, desc = _fmt_cond({"all": ["ult1", "link"]})
-        self.assertEqual(typ, "全部满足")
-        self.assertEqual(desc, "终结技 1 可用;连携技可用")
-
-        typ, desc = _fmt_cond({"any": ["skill>=2"]})
-        self.assertEqual(typ, "任一满足")
-        self.assertEqual(desc, "技力≥2")
-
-    @patch("src.gui.ConditionalRotationPanel._tr", side_effect=lambda x: x)
-    def test_fmt_actions(self, _):
-        self.assertEqual(_fmt_actions(["1", "e", "ult_2"]), "战技 1;连携技;终结技 2")
-        self.assertEqual(_fmt_actions([]), "无")
-        self.assertEqual(_fmt_actions("notalist"), "无")
-
-
-class TestConditionDisplayCard(unittest.TestCase):
-    """只读显示卡片往返测试。"""
-
-    @classmethod
-    def setUpClass(cls):
-        cls.app = QApplication.instance() or QApplication([])
-
-    @patch("src.gui.ConditionalRotationPanel._tr", side_effect=lambda x: x)
-    def test_card_holds_node(self, _):
-        node = {"if": "link", "then": ["e"], "else": ["1"]}
-        card = _ConditionDisplayCard(node)
-        self.assertEqual(card._node, node)
-
-    @patch("src.gui.ConditionalRotationPanel._tr", side_effect=lambda x: x)
-    def test_card_update_node(self, _):
-        card = _ConditionDisplayCard({"if": "link", "then": ["1"]})
-        new_node = {"if": "ult2", "then": ["e", "2"], "else": ["3"]}
-        card.update_node(new_node)
-        self.assertEqual(card._node, new_node)
+from src.gui.ConditionalRotationPanel import _ConditionEditDialog
 
 
 class TestConditionEditDialog(unittest.TestCase):
@@ -106,60 +41,6 @@ class TestConditionEditDialog(unittest.TestCase):
         self.assertEqual(result["if"], {"all": ["ult1", "link"]})
         self.assertEqual(result["then"], ["1", "2"])
         self.assertNotIn("else", result)
-
-    @patch("src.gui.ConditionalRotationPanel._tr", side_effect=lambda x: x)
-    def test_dialog_skill_cond(self, _):
-        node = {"if": "skill>=2", "then": ["1"]}
-        dlg = _ConditionEditDialog(node, self.parent)
-        self.assertEqual(dlg.to_node()["if"], "skill>=2")
-
-
-class TestConditionEditor(unittest.TestCase):
-    """条件编辑器往返测试。"""
-
-    @classmethod
-    def setUpClass(cls):
-        cls.app = QApplication.instance() or QApplication([])
-
-    @patch("src.gui.ConditionalRotationPanel._tr", side_effect=lambda x: x)
-    def test_editor_atom(self, _):
-        self.assertEqual(_ConditionEditor("link").to_cond(), "link")
-        self.assertEqual(_ConditionEditor("ult2").to_cond(), "ult2")
-
-    @patch("src.gui.ConditionalRotationPanel._tr", side_effect=lambda x: x)
-    def test_editor_skill(self, _):
-        self.assertEqual(_ConditionEditor("skill>=2").to_cond(), "skill>=2")
-
-    @patch("src.gui.ConditionalRotationPanel._tr", side_effect=lambda x: x)
-    def test_editor_all_any(self, _):
-        self.assertEqual(
-            _ConditionEditor({"all": ["ult1", "link"]}).to_cond(),
-            {"all": ["ult1", "link"]},
-        )
-        self.assertEqual(
-            _ConditionEditor({"any": ["skill>=2"]}).to_cond(),
-            {"any": ["skill>=2"]},
-        )
-
-
-class TestActionListEditor(unittest.TestCase):
-    """动作列表编辑器往返测试。"""
-
-    @classmethod
-    def setUpClass(cls):
-        cls.app = QApplication.instance() or QApplication([])
-
-    @patch("src.gui.ConditionalRotationPanel._tr", side_effect=lambda x: x)
-    def test_editor_roundtrip(self, _):
-        editor = _ActionListEditor("运行：")
-        editor.load(["1", "e", "ult_2", "sleep_5"])
-        self.assertEqual(editor.to_list(), ["1", "e", "ult_2", "sleep_5"])
-
-    @patch("src.gui.ConditionalRotationPanel._tr", side_effect=lambda x: x)
-    def test_editor_empty(self, _):
-        editor = _ActionListEditor("运行：")
-        editor.load([])
-        self.assertEqual(editor.to_list(), [])
 
 
 if __name__ == "__main__":

--- a/tests/TestDeliveryAreaConfig.py
+++ b/tests/TestDeliveryAreaConfig.py
@@ -2,86 +2,10 @@
 import unittest
 from unittest.mock import Mock, call
 
-from src.data.delivery_area import DELIVERY_AREA_CONFIG
-from src.data import delivery_area_service
 from src.tasks.onetime.DeliveryTask import DeliveryTask
 
 
 class TestDeliveryAreaConfig(unittest.TestCase):
-    def test_get_transfer_search_area_returns_preset_config(self):
-        self.assertEqual(
-            delivery_area_service.get_transfer_search_area("武陵城", "武陵"),
-            {"preset": "top"},
-        )
-        self.assertEqual(
-            delivery_area_service.get_transfer_search_area("试验园区", "武陵"),
-            {"preset": "right"},
-        )
-
-    def test_get_transfer_search_area_supports_custom_box_config(self):
-        area_name = "测试区域"
-        DELIVERY_AREA_CONFIG[area_name] = {
-            "delivery_locations": ["测试点"],
-            "delivery_targets_by_location": {"测试点": []},
-            "transfer_search_area": {
-                "测试点": {"x": 0.1, "y": 0.2, "to_x": 0.8, "to_y": 0.9},
-            },
-            "ocr_priority_locations": ["测试点"],
-        }
-        try:
-            self.assertEqual(
-                delivery_area_service.get_transfer_search_area("测试点", area_name),
-                {"x": 0.1, "y": 0.2, "to_x": 0.8, "to_y": 0.9},
-            )
-        finally:
-            DELIVERY_AREA_CONFIG.pop(area_name, None)
-
-    def test_get_task_model_area_returns_configured_value(self):
-        self.assertEqual(
-            delivery_area_service.get_task_model_area("武陵"),
-            "武陵",
-        )
-
-    def test_get_delivery_target_ocr_pattern_matches_literal(self):
-        pattern = delivery_area_service.get_delivery_target_ocr_pattern("武陵", "常沄")
-        self.assertIsNotNone(pattern.search("常沄"))
-        # OCR 字符混淆由 src/ocr_text_fix_patch.py 运行时 patch 处理，此处不测试
-
-    def test_get_accept_feature_labels_returns_mapping_by_target_ticket(self):
-        self.assertEqual(
-            delivery_area_service.get_accept_feature_labels("武陵", "73100"),
-            ["wuling_7_31w"],
-        )
-        self.assertEqual(
-            delivery_area_service.get_accept_feature_labels("武陵", "79800"),
-            ["wuling_7_98w"],
-        )
-        self.assertEqual(
-            delivery_area_service.get_accept_feature_labels("武陵", "119000"),
-            ["wuling_11_9w"],
-        )
-        self.assertEqual(
-            delivery_area_service.get_accept_feature_labels("武陵", "000000"),
-            [],
-        )
-
-    def test_get_accept_feature_labels_returns_empty_for_invalid_label(self):
-        area_name = "测试区域"
-        DELIVERY_AREA_CONFIG[area_name] = {
-            "feature_label_area_code": "test_area",
-            "delivery_locations": ["测试点"],
-            "delivery_targets_by_location": {"测试点": []},
-            "transfer_search_area": {"测试点": {"preset": "top"}},
-            "ocr_priority_locations": ["测试点"],
-        }
-        try:
-            self.assertEqual(
-                delivery_area_service.get_accept_feature_labels(area_name, "73100"),
-                [],
-            )
-        finally:
-            DELIVERY_AREA_CONFIG.pop(area_name, None)
-
     def test_accept_order_ticket_priority_stops_after_first_match(self):
         task = object.__new__(DeliveryTask)
         task.delivery_area = "武陵"

--- a/tests/TestGameWindow.py
+++ b/tests/TestGameWindow.py
@@ -21,13 +21,6 @@ class TestGameWindow(unittest.TestCase):
 
         self.assertEqual(hwnd, 200)
 
-    @patch("src.core.game_window.win32gui")
-    def test_find_game_hwnd_returns_zero_when_no_window_matches(self, win32gui):
-        win32gui.GetForegroundWindow.return_value = 0
-        win32gui.EnumWindows.side_effect = lambda callback, context: None
-
-        self.assertEqual(find_game_hwnd({"hwnd_class": "UnityWndClass"}, timeout=0), 0)
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/TestGifIcon.py
+++ b/tests/TestGifIcon.py
@@ -48,17 +48,6 @@ class GifIconTestCase(unittest.TestCase):
         cls.light_path = _make_gif(cls.tmp / "light.gif")
         cls.dark_path = _make_gif(cls.tmp / "dark.gif")
 
-    def test_gif_icon_path_and_icon(self):
-        icon = GifIcon(self.single_path)
-        self.assertEqual(icon.path(), self.single_path)
-        qicon = icon.icon()
-        self.assertFalse(qicon.isNull())
-        # 引擎图标没有预置尺寸，但可通过 pixmap() 取当前帧
-        pm = qicon.pixmap(32, 32)
-        self.assertFalse(pm.isNull())
-        self.assertEqual(pm.width(), 32)
-        self.assertEqual(pm.height(), 32)
-
     def test_icon_widget_registers_and_animates(self):
         icon = GifIcon(self.single_path)
         widget = IconWidget(icon)
@@ -92,17 +81,6 @@ class GifIconTestCase(unittest.TestCase):
         self.assertTrue(any(widget in player._widgets for player in
                             (icon._light_gif._player, icon._dark_gif._player)))
         widget.close()
-
-    def test_theme_icon_static_suffixes_still_work(self):
-        # png/svg 走原有渲染路径，不应被 GIF 逻辑影响
-        png = ThemeIcon("a", "b", suffix=".png", base_path=self.tmp)
-        self.assertFalse(png._is_gif)
-        self.assertEqual(png.path(Theme.LIGHT), str(self.tmp / "a.png"))
-        self.assertEqual(png.path(Theme.DARK), str(self.tmp / "b.png"))
-
-    def test_theme_icon_rejects_bad_suffix(self):
-        with self.assertRaises(AssertionError):
-            ThemeIcon("a", "b", suffix=".webp")
 
     def test_missing_file_degrades_gracefully(self):
         icon = GifIcon(str(self.tmp / "not_exists.gif"))
@@ -183,16 +161,6 @@ class ThemeIconInvertTestCase(unittest.TestCase):
         self.assertLessEqual(abs(center[0] - 0), 8)
         self.assertGreaterEqual(center[1], 247)
         self.assertEqual(center[3], 255)
-
-    def test_both_provided_no_cache(self):
-        icon = ThemeIcon("a", "b", suffix=".png", base_path=self.tmp)
-        self.assertEqual(icon._light_path, str(self.tmp / "a.png"))
-        self.assertEqual(icon._dark_path, str(self.tmp / "b.png"))
-        self.assertEqual(list(self.cache.glob("*")), [])
-
-    def test_neither_provided_raises(self):
-        with self.assertRaises(ValueError):
-            ThemeIcon(suffix=".png", base_path=self.tmp)
 
     def test_missing_source_warns_and_falls_back(self):
         # 源文件缺失：不崩溃，路径回落到源路径（渲染为空）

--- a/tests/TestLogZipDedup.py
+++ b/tests/TestLogZipDedup.py
@@ -17,10 +17,6 @@ from src.patches.log_zip_dedup import (
 
 class TestLogZipDedup(unittest.TestCase):
 
-    def test_md5_hex_returns_same_hash_for_same_bytes(self):
-        self.assertEqual(md5_hex(b"abc"), "900150983cd24fb0d6963f7d28e17f72")
-        self.assertNotEqual(md5_hex(b"abc"), md5_hex(b"abd"))
-
     def test_collect_image_duplicates_keeps_first_and_records_rest(self):
         entries = [
             ("screenshots/a_original.png", b"same"),

--- a/tests/TestMouseRotationCalibration.py
+++ b/tests/TestMouseRotationCalibration.py
@@ -2,7 +2,6 @@
 """鼠标视角旋转系数标定任务的单元测试。"""
 import unittest
 
-from src.config import config
 from src.tasks.test.MouseRotationCalibration import (
     MouseRotationCalibration,
     angle_delta,
@@ -25,25 +24,6 @@ class TestAngleDelta(unittest.TestCase):
 
     def test_half_turn(self):
         self.assertAlmostEqual(angle_delta(180, 0), -180.0)
-
-
-class TestMouseRotationCalibrationTask(unittest.TestCase):
-    """验证新任务能够被任务系统正常发现。"""
-
-    def test_registered_in_onetime_tasks(self):
-        modules = [module for module, _ in config.get("onetime_tasks", [])]
-        self.assertIn("src.tasks.test.MouseRotationCalibration", modules)
-
-    def test_task_class_importable(self):
-        self.assertTrue(issubclass(MouseRotationCalibration, object))
-        self.assertTrue(callable(angle_delta))
-
-    def test_calibration_defaults(self):
-        self.assertEqual(MouseRotationCalibration.CALIBRATION_DX, 100)
-        self.assertEqual(MouseRotationCalibration.REPEAT_COUNT, 4)
-        self.assertEqual(MouseRotationCalibration.ANGLE_REFRESH_DELAY, 0.1)
-        self.assertEqual(MouseRotationCalibration.MIN_SCORE, 0.6)
-        self.assertEqual(MouseRotationCalibration.VERIFY_PAIR_LR, True)
 
 
 class TestPairLeftRight(unittest.TestCase):

--- a/tests/TestQfluentNavigationPatch.py
+++ b/tests/TestQfluentNavigationPatch.py
@@ -65,9 +65,6 @@ class TestQfluentNavigationPatch(unittest.TestCase):
         cls._original = NavigationPanel._onIndicatorAniFinished
         install_qfluent_navigation_patch()
 
-    def test_patch_installed(self):
-        self.assertIsNot(NavigationPanel._onIndicatorAniFinished, self._original)
-
     def test_no_crash_when_indicator_item_none(self):
         # 窗口未显示时 _findIndicatorItem 返回 None，原方法会抛 AttributeError
         panel = _FakePanel(_FakeWidget(), indicator_item=None)

--- a/tests/TestScreenshotSidecar.py
+++ b/tests/TestScreenshotSidecar.py
@@ -12,7 +12,6 @@ from src.patches.screenshot_sidecar import (
     rebuild_boxed_images,
     render_boxed_image,
     serialize_boxes,
-    sidecar_path_of,
 )
 
 
@@ -52,12 +51,6 @@ class TestScreenshotSidecar(unittest.TestCase):
         self.assertEqual(boxes[0]["name"], "无名字段")
         self.assertEqual(boxes[0]["text"], "无名字段")
 
-    def test_build_sidecar_structure(self):
-        sidecar = build_sidecar("a_original.png", [{"x": 1}])
-        self.assertEqual(sidecar["format"], 1)
-        self.assertEqual(sidecar["image"], "a_original.png")
-        self.assertEqual(sidecar["boxes"], [{"x": 1}])
-
     def test_render_boxed_image_draws_rectangle(self):
         with tempfile.TemporaryDirectory() as tmp:
             tmp = Path(tmp)
@@ -77,12 +70,6 @@ class TestScreenshotSidecar(unittest.TestCase):
                 self.assertEqual(img.getpixel((10, 40)), (255, 60, 60))  # 左边框
                 self.assertEqual(img.getpixel((89, 40)), (255, 60, 60))  # 右边框
                 self.assertEqual(img.getpixel((50, 40)), (255, 255, 255))  # 框内部保持原色
-
-    def test_sidecar_path_of_derives_name(self):
-        self.assertEqual(
-            sidecar_path_of("20260728_152007_日常任务_original.png").name,
-            "20260728_152007_日常任务_boxes.json",
-        )
 
     def test_rebuild_boxed_images(self):
         with tempfile.TemporaryDirectory() as tmp:

--- a/tests/TestYoloDetect.py
+++ b/tests/TestYoloDetect.py
@@ -60,11 +60,6 @@ class TestYoloDetect(unittest.TestCase):
         self.assertEqual(1, len(results))
         self.assertEqual(0, len(task.draw_calls))
 
-    def test_yolo_detect_requires_name(self):
-        task = _DummyTask(debug=False)
-        with self.assertRaises(ValueError):
-            task.yolo_detect(name=[])
-
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/TestZipLineConfig.py
+++ b/tests/TestZipLineConfig.py
@@ -9,22 +9,10 @@ from ok.util.file import read_json_file, write_json_file
 
 from src.core import config_migration, global_config_store
 from src.tasks.account import account_scope_store
-from src.core.global_config_store import (
-    ZIP_LINE_CONFIG_NAME,
-    ZIP_LINE_CONFIG_TYPE,
-    ZIP_LINE_DELIVERY_GROUP,
-    ZIP_LINE_GATHER_GROUP,
-    ZIP_LINE_GROUP_KEY,
-)
+from src.core.global_config_store import ZIP_LINE_CONFIG_NAME
 
 
 class TestZipLineConfig(unittest.TestCase):
-    def test_zipline_config_has_explicit_route_groups(self):
-        group_meta = ZIP_LINE_CONFIG_TYPE[ZIP_LINE_GROUP_KEY]
-        self.assertEqual(group_meta["options"], [ZIP_LINE_DELIVERY_GROUP, ZIP_LINE_GATHER_GROUP])
-        self.assertIn(ZIP_LINE_DELIVERY_GROUP, group_meta["sub_configs"])
-        self.assertIn(ZIP_LINE_GATHER_GROUP, group_meta["sub_configs"])
-
     @patch("src.tasks.account.account_scope_store.update_overrides")
     def test_legacy_account_routes_move_to_shared_zipline_config(self, update_overrides):
         global_config_store._migrate_legacy_zip_line_account_overrides()


### PR DESCRIPTION
## 概要

此 PR 对所有测试文件进行了清理，移除了低价值测试（多数为 AI 顺手拉的屎）。

低价值测试的定义是：

- 由标准库或编程语言特性决定的代码逻辑
  - 例如，测试 Python md5 库是否能正常运行是没有意义的
- 仅测试 常量是否成功定义 的测试（最常见）
  - 此类测试会导致 Coding Agent 修改一处常量定义需要同时修改一处测试，增加维护负担
- 仅测试 字符串是否恒等 的测试
- 仅为覆盖率设置的测试或者重复测试
- trivial getter


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **重构**
  * 移除未使用的自动拾取辅助逻辑和手动 OCR 测试入口，自动拾取与据点兑换功能保持不变。
* **测试**
  * 清理多项重复、过时或非核心测试，保留主要功能、配置回退、界面行为及数据处理测试。
* **维护**
  * 删除相关未使用依赖、配置项和测试辅助代码，减少维护负担。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->