### PR TITLE
fix: revert wait_pop_up to find_one loop implementation

### DIFF
--- a/src/core/base_mixin/game_flow_mixin.py
+++ b/src/core/base_mixin/game_flow_mixin.py
@@ -175,7 +175,7 @@ class GameFlowMixin:
         while True:
             if self.active_time() - start_time > time_out:
                 return False
-            if count > 30:
+            if count >= 30:
                 return False
             result = self.find_one(
                 feature=fL.reward_ok, box=self.box.bottom, threshold=0.8

--- a/src/core/base_mixin/game_flow_mixin.py
+++ b/src/core/base_mixin/game_flow_mixin.py
@@ -162,7 +162,6 @@ class GameFlowMixin:
     def wait_pop_up(self, time_out=15, after_sleep=0):
         """
         等待奖励弹窗出现并点击 OK 按钮。
-        使用 click_feature 持续点击直到弹窗消失。
 
         Args:
             time_out: 总超时时间。
@@ -171,23 +170,22 @@ class GameFlowMixin:
         Returns:
             bool: 找到并点击返回 True，超时返回 False。
         """
-        clicked = self.click_feature(
-            fL.reward_ok,
-            boxes=[self.box.bottom],
-            time_out=time_out,
-            after_sleep=after_sleep,
-        )
-        if clicked:
-            return True
-        result = self.wait_ocr(
-            match=self.lang.game_flow_mixin.k_8b2ca27a,
-            time_out=1,
-            box=self.box.bottom,
-        )
-        if result:
-            self.click(result, after_sleep=after_sleep)
-            return True
-        return False
+        count = 0
+        start_time = self.active_time()
+        while True:
+            if self.active_time() - start_time > time_out:
+                return False
+            if count > 30:
+                return False
+            result = self.find_one(
+                feature=fL.reward_ok, box=self.box.bottom, threshold=0.8
+            )
+            if not result:
+                result = self.wait_ocr(match=self.lang.game_flow_mixin.k_8b2ca27a, time_out=1, box=self.box.bottom)
+            if result:
+                self.click(result, after_sleep=after_sleep)
+                return True
+            count += 1
 
     def wait_login(self):
         """


### PR DESCRIPTION
## 变更说明

回滚 `wait_pop_up` 方法到之前的 `find_one` 循环实现，撤销 commit 9fe9f7a 中改用 `click_feature` 的变更。

### 回滚内容

- **移除** `click_feature` 调用，恢复为 `find_one` + `wait_ocr` 循环查找
- **恢复** `count > 30` 和 `time_out` 的双重超时检测机制
- 保持 `fL.reward_ok` 枚举引用（与当前代码库风格一致）

### 原实现逻辑

```python
count = 0
start_time = self.active_time()
while True:
    if self.active_time() - start_time > time_out:
        return False
    if count > 30:
        return False
    result = self.find_one(feature=fL.reward_ok, box=self.box.bottom, threshold=0.8)
    ...
```

### 回滚原因

click_feature 实现在当前场景下表现不如预期，需要恢复到稳定的 find_one 循环方案。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * 优化奖励确认弹窗的检测与点击流程，支持优先识别按钮并在必要时使用文字识别。
  * 增加总超时和最多 30 次检测限制，避免弹窗处理长时间无响应。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->