### PR TITLE
fix: 对中逻辑启用放大选项改为每次循环滚轮一次，移除 do_scroll sleep

### DIFF
--- a/src/tasks/mixin/navigation_mixin.py
+++ b/src/tasks/mixin/navigation_mixin.py
@@ -395,12 +395,12 @@ class NavigationMixin(SearchMixin):
         success = False
         random_move_count = 0
         move_count = 0
-        scroll_bool = False
         sum_dx = 0
         sum_dy = 0
-        move_bool = False
         for i in range(max_time*2):
             start_action_time = self.active_time()
+            if need_scroll:
+                self.do_scroll(1, 400)
             if ocr:
                 # 使用OCR模式识别目标，设置超时时间为2秒，并启用日志记录
                 start_time = self.active_time()
@@ -550,17 +550,7 @@ class NavigationMixin(SearchMixin):
 
             if self.active_time() - start_action_time < once_time:
                 self.sleep(once_time - (self.active_time() - start_action_time))  # OCR 成功后不需要处理，下一次失败仍然随机
-            if need_scroll:
-                # 初始放大（只执行一次）
-                if not scroll_bool:
-                    scroll_bool = True
-                    self.do_scroll(8, 400)
 
-                # 时间节点控制
-                scroll_plan = {int(max_time * 0.250): -400, int(max_time * 0.500): -400, int(max_time * 0.750): -400}
-
-                if i in scroll_plan:
-                    self.do_scroll(2, scroll_plan[i])
         if raise_if_fail:
             raise Exception("对中失败")
         else:
@@ -569,4 +559,3 @@ class NavigationMixin(SearchMixin):
     def do_scroll(self, times, delta):
         for _ in range(times):
             pyautogui.scroll(int(self.resolution_scale() * delta))
-            self.sleep(0.1)

--- a/src/tasks/mixin/navigation_mixin.py
+++ b/src/tasks/mixin/navigation_mixin.py
@@ -397,7 +397,7 @@ class NavigationMixin(SearchMixin):
         move_count = 0
         sum_dx = 0
         sum_dy = 0
-        for i in range(max_time*2):
+        for _ in range(max_time*2):
             start_action_time = self.active_time()
             if need_scroll:
                 self.do_scroll(1, 400)


### PR DESCRIPTION
## 改动说明

`align_ocr_or_find_target_to_center` 中 `need_scroll` 逻辑重构：

1. **每次循环迭代开头执行 `do_scroll(1, 400)`** — 启用放大选项后，每轮对中循环开始时滚轮放大一次，确保持续放大视角
2. **移除 `do_scroll` 中的 `self.sleep(0.1)`** — 滚轮操作不再有 100ms 延迟，提升响应速度
3. **删除旧逻辑** — 移除了"初始放大 8 次 + 时间节点缩回（25%/50%/75%）"的复杂控制，以及不再使用的 `scroll_bool`、`move_bool` 变量

### 影响范围

- `need_scroll=True` 的调用方（滑索对齐等）行为变化：从"首次放大后按时间节点缩回"变为"每轮持续放大"
- `do_scroll` 是通用方法，移除 sleep 后所有调用方都会变快

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **问题修复**
  * 优化 OCR 对齐过程中的页面滚动行为，使每轮对齐均按需执行固定滚动。
  * 移除不必要的初始放大、分阶段滚动及额外等待，提升对齐操作的稳定性与响应速度。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->