### PR TITLE
fix: 终结技后等待重新识别编队

### DIFF
--- a/src/tasks/mixin/battle_mixin.py
+++ b/src/tasks/mixin/battle_mixin.py
@@ -44,6 +44,7 @@ from src.core.BattleConfig import (
     ULT_RELEASE_MODE_HOLD,
 )
 from src.core.config_migration import legacy_battle_mode_to_bool
+from src.data.skill_allowlist import detect_team_from_frame
 from src.core.global_config_store import get_global_config
 from src.image.recommend_skill_detector import get_recommend_skill_detector
 
@@ -235,18 +236,26 @@ class BattleMixin(BaseEfTask):
                     self.send_key_down("alt")
                     self.send_key(ult)  # 确认使用send_key：终极技键位为游戏固定不可配置键，不经过KeyConfigManager管理
                     self.send_key_up("alt")
-                    # 等待技能释放导致战斗状态变化
+                    # 等待技能释放导致战斗状态变化，然后等待重新识别到至少一个人
                     self.wait_until(lambda: not self.in_combat(), time_out=1)
-                    self.wait_until(lambda: self.in_team(), time_out=3)
+                    self.wait_until(self._has_detected_team_member, time_out=3)
                     return True
                 self.send_key_down(ult)  # 确认使用send_key：终极技键位为游戏固定不可配置键，不经过KeyConfigManager管理
                 # 等待技能释放导致战斗状态变化
                 self.wait_until(lambda: not self.in_combat(), time_out=1)
                 self.send_key_up(ult)  # 确认使用send_key：终极技键位为游戏固定不可配置键，释放按键
-                self.wait_until(lambda: self.in_team(), time_out=3)
+                # wait_until 每轮会刷新 self.frame，再重新识别当前编队
+                self.wait_until(self._has_detected_team_member, time_out=3)
                 return True
 
         return False
+
+    def _has_detected_team_member(self):
+        """当前帧至少识别到一个编队成员时返回 True。"""
+        frame = self.frame
+        if frame is None or frame.size == 0:
+            return False
+        return any(member != "?" for member in detect_team_from_frame(frame))
 
     def use_link_skill(self):
         """

--- a/tests/TestStateDrivenWaits.py
+++ b/tests/TestStateDrivenWaits.py
@@ -1,6 +1,7 @@
 import unittest
 from unittest.mock import patch
 
+import numpy as np
 from ok import Box
 from src.core.base_mixin.game_flow_mixin import GameFlowMixin
 from src.core.base_mixin.runtime_mixin import RuntimeMixin
@@ -456,6 +457,18 @@ class TestStateDrivenWaits(unittest.TestCase):
         task = StubTask()
         self.assertTrue(BattleMixin.in_team(task))
         self.assertEqual(task._battle_member_count, 1)
+
+    @patch("src.tasks.mixin.battle_mixin.detect_team_from_frame")
+    def test_detected_team_member_rechecks_current_frame(self, detect_team):
+        detect_team.side_effect = [["?", "?"], ["余烬", "?"]]
+
+        class StubTask:
+            frame = np.zeros((10, 10, 3), dtype=np.uint8)
+
+        task = StubTask()
+        self.assertFalse(BattleMixin._has_detected_team_member(task))
+        self.assertTrue(BattleMixin._has_detected_team_member(task))
+        self.assertEqual(detect_team.call_count, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 摘要

- 终结技释放后通过最新帧持续重新识别编队成员
- 避免等待逻辑反复检查首次识别得到的静态结果
- 为编队成员重新识别行为补充回归测试

## 测试

- `python -m unittest tests.TestStateDrivenWaits`（21 项通过）

## 说明

完整测试集当前存在一项与本次更改无关的既有配置断言失败：`TestAccountBattleConfig.test_task_config_uses_independent_switch`。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化终极技释放后的状态识别：重新检测到至少一名有效队员后再继续操作。
  * Alt 释放和普通释放流程统一采用更可靠的队伍识别逻辑。

* **测试**
  * 增加队伍识别重试场景测试，确保首次未识别到成员时会继续检测。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->