### PR TITLE
ci: 引入ruff格式化及其自动化Workflow

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -1,0 +1,75 @@
+name: Format
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 23 * * *"
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  format:
+    if: ${{ github.repository_owner == 'AliceJump' }}
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: checkout
+        uses: actions/checkout@v6
+
+      - name: setup python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: install uv
+        run: pip install uv
+
+      - name: install deps
+        run: uv sync --group dev
+
+      - name: ruff check fix and format
+        run: |
+          uv run ruff check --fix .
+          uv run ruff format .
+
+      - name: commit to branch
+        id: commit
+        run: |
+          git config user.name github-actions
+          git config user.email github-actions@github.com
+
+          git add -A
+
+          if ! git diff --cached --quiet; then
+            BRANCH="style/format-$(date -u +%Y%m%d%H%M%S)"
+            echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
+            git checkout -b "$BRANCH"
+            git commit -m "chore: ruff format"
+          fi
+
+      - name: push branch and open PR
+        if: steps.commit.outputs.branch != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          BRANCH="${{ steps.commit.outputs.branch }}"
+          git push -u origin "$BRANCH"
+          gh pr create --base master --head "$BRANCH" \
+            --title "style: format files" \
+            --body "由 format 工作流自动生成的代码格式化更新。"
+          echo "Created new PR for $BRANCH"
+          # 启用 auto-merge：checks 通过后自动 squash 合并（master ruleset approval=0）；
+          # PR 已是 clean status（无待等待的 check）时 enablePullRequestAutoMerge 会被拒绝，
+          # 此时所有合并条件已满足，直接合并即可
+          if ! gh pr merge "$BRANCH" --auto --squash --delete-branch \
+                --subject "style: format files" \
+                --body "由 format 工作流自动生成的代码格式化更新。"; then
+            echo "Auto-merge unavailable (clean status), merging directly"
+            gh pr merge "$BRANCH" --squash --delete-branch \
+              --subject "style: format files" \
+              --body "由 format 工作流自动生成的代码格式化更新。"
+          fi
+          echo "Merged or auto-merge enabled for $BRANCH"

--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,7 @@ __pycache__/
 *$py.class
 *.pyc
 *.pyo
+.ruff_cache/
 
 ############################
 # 🏗 构建产物
@@ -77,6 +78,7 @@ python/
 .idea/
 .vscode/*
 !.vscode/extensions.json
+!.vscode/settings.json
 .workbuddy/
 
 ############################

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,5 +1,7 @@
 {
   "recommendations": [
-    "AliceJump.ok-lang-hints"
+    "AliceJump.ok-lang-hints",
+    "charliermarsh.ruff",
+    "ms-python.python"
   ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,18 @@
+{
+  // Editor Formatting Settings
+  "editor.formatOnSave": true,
+  "[python]": {
+    "editor.defaultFormatter": "charliermarsh.ruff",
+    "editor.codeActionsOnSave": {
+      "source.fixAll.ruff": "explicit",
+      "source.organizeImports.ruff": "explicit"
+    },
+    "editor.rulers": [120],
+    "files.insertFinalNewline": true,
+    "files.trimFinalNewlines": true,
+    "files.trimTrailingWhitespace": true,
+  },
+  // Python Evenvironment Settings
+  "python.defaultInterpreterPath": "${workspaceFolder}/.venv/Scripts/python.exe",
+  "python.terminal.activateEnvironment": true
+}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,16 +1,22 @@
 # AGENTS.md
 
-项目级强制规则。每次会话开始必须读取并遵守。
+项目级强制规则，每次会话开始必须读取并遵守。如果工作中发现此文档所述的内容已过时，需要主动向用户确认是否要修改。
 
-## 提交与 PR 强制规则（最高优先级，必须先读）
+## 提交与 PR 强制规则（最高优先级）
 
 ### PowerShell 双引号字符串中的反引号（必踩坑）
 
-在 PowerShell 双引号字符串里，反引号 `` ` `` 是**转义字符**而非字面量：`` `$HOME `` 保留字面量不展开，而 `$HOME` 会展开变量；合法转义如 `` `a ``（0x07）、`` `r ``（CR）、`` `n ``（LF）会变成控制字符；未知序列如 `` `s `` 会**移除反引号、保留原字符**（`` "Use `src` END" `` → `Use src END`）。给 `gh pr create/edit --body "..."` 等传 Markdown（含代码反引号）时：
+在 PowerShell **双引号字符串里**，反引号 `` ` `` 是**转义字符**而非字面量，规则：
+
+- 变量展开：`` `$HOME `` 保留字面量不展开，而 `` $HOME `` 会展开变量；
+- 合法转义序列：如 `` `a ``（0x07）、`` `r ``（CR）、`` `n ``（LF）会变成控制字符；
+- 未知转义序列：如 `` `s `` 会移除反引号、保留原字符（例如 `` "Use `src` END" `` 会变成 `` Use src END ``）。
+
+给 `gh pr create/edit --body "..."` 等传 Markdown（含代码块反引号）时：
 
 - **必须用单引号字符串**（`'...'` 或 `@'...'@` here-string），单引号内反引号是字面量（`` 'Use `src` END' `` → `` Use `src` END ``），`gh pr edit --body $body` 传变量也可；
-- **禁止用双引号传含反引号的 body**——反引号会被移除或变控制字符（如 `` `assets `` 里的 `` `a `` 变成 `^G`），造成 PR 描述格式错乱；
-- 已踩坑案例：PR #194、PR #203 的 body 中 `` `src/...` `` 全部丢失或变 `^G`，需 `gh pr edit` 重新提交。
+- **禁止用双引号传含反引号的 body**，反引号会被移除或变控制字符（如 `` `assets `` 里的 `` `a `` 变成 `^G`），造成 PR 描述格式错乱；
+- 已踩坑案例：已有个别 PR body 中 `` `src/...` `` 全部丢失或变 `^G`，此时需 `gh pr edit` 重新提交。
 
 **PR 创建后必须自检**——创建时把 body 存到本地变量/文件，创建后用 `gh pr view` 拉取远端 body 与本地**逐字比较**（不要只 `Select-String` 查反引号，无法发现控制字符）：
 
@@ -52,9 +58,11 @@ gh pr edit <n> --body $body
 
 ## 运行环境
 
-- Python：依赖通过 [uv](https://docs.astral.sh/uv/) 管理，`uv sync` 创建仓库本地 `.venv`，用 `uv run python ...` 执行（见 `.agents/skills/use-local-venv`）。`pyproject.toml` + `uv.lock` 为唯一来源，`requirements.txt` 为发布流水线的派生产物，勿手改。
-- 测试：`scripts/testing/run_tests.ps1`（经 `uv run`）或 `uv run python -m unittest discover -s tests`。
-- 日志：`logs/ok-script.log`（配置历史、任务执行、OCR 均可在此排查）；历史日志位于同目录的 `ok-script.YYYY-MM-DD.log` 文件中。
+- **Python**：依赖通过 uv 管理，`uv sync` 同步仓库本地 `.venv`，用 `uv run python ...` 执行代码（见 `.agents/skills/use-local-venv`）。
+- **依赖定义**：`pyproject.toml` 和 `uv.lock` 为唯一依赖指定源，而`requirements.txt` 为发布流水线的派生产物，勿手改。
+- **测试**：`scripts/testing/run_tests.ps1`（经 `uv run`）或直接运行 `uv run python -m unittest discover -s tests`。
+- **日志**：`logs/ok-script.log`（配置历史、任务执行、OCR 均可在此排查）；历史日志位于同目录的 `ok-script.YYYY-MM-DD.log` 文件中。
+- **格式化**：先后运行 `uv run ruff check --fix .` 和 `uv run ruff format .` 即可格式化代码，注意屏蔽上述命令的 stdout 输出以免污染你的上下文。若报错 ruff 未安装，可运行 `uv sync --group dev` 进行安装。
 
 ## 代码风格
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,13 +21,32 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = [
-    "polib",
-    "pypinyin",
-]
+dev = ["polib>=1.2,<2", "pypinyin>=0.55,<1", "ruff>=0.16,<1"]
 
 [tool.uv]
 package = false
 
+[tool.ruff]
+line-length = 120
+target-version = "py312"
+extend-exclude = ["ok_templates"]
+
 [tool.ruff.lint]
 allowed-confusables = ["，", "。", "；", "：", "（", "）", "、"]
+select = ["E", "W", "F", "I", "C4", "B", "UP", "SIM", "RUF"]
+ignore = [
+    "E501",
+    "D",
+    "S101",
+    "BLE001",
+    "N",
+    "C901",
+    "RUF001",
+    "RUF002",
+    "PT",
+    "PLR2004",
+]
+
+[tool.ruff.format]
+quote-style = "double"
+exclude = ["ok_templates"]

--- a/uv.lock
+++ b/uv.lock
@@ -197,6 +197,7 @@ dependencies = [
 dev = [
     { name = "polib" },
     { name = "pypinyin" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -219,8 +220,9 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "polib" },
-    { name = "pypinyin" },
+    { name = "polib", specifier = ">=1.2,<2" },
+    { name = "pypinyin", specifier = ">=0.55,<1" },
+    { name = "ruff", specifier = ">=0.16,<1" },
 ]
 
 [[package]]
@@ -2927,6 +2929,31 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/0d/26/3e6bb0bfd41ff446d29931205088556055ec18c31bf099d6719c281c448c/rubicon_objc-0.5.6.tar.gz", hash = "sha256:0d3b0a9889f72916c095a58e7e1c275c260cb8a86b8ef8b909e60cb002fd54d5", size = 189833, upload-time = "2026-07-02T06:08:16.38Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/26/a6/cf07f7f931a7fab57b866ed086b15e75bff4a908084b71e74b42798207bf/rubicon_objc-0.5.6-py3-none-any.whl", hash = "sha256:b53f6fc458d78ddf2ce82365c34e234ae85cd8217c983438ae4bf9e1bd1252b3", size = 66152, upload-time = "2026-07-02T06:08:14.995Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.16.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f3/85/c8e12473c93018f92d19dd988a294202e1c27426c47ec4de53ffb847b8d8/ruff-0.16.5.tar.gz", hash = "sha256:1b88500f9ffbcab3dedb0082c9f9492e91ec3d618aac1236a3e0189938f7040b", size = 4912003, upload-time = "2026-08-27T16:34:18.258Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/b6/77c90a970fe2dae17a723acbd011043ea97c98d7deacccefdc4ba74ec512/ruff-0.16.5-py3-none-linux_armv6l.whl", hash = "sha256:12e5f673e774c35fbb62f288809c7653b73445f8ecec6b6063fd6ea3521aa14b", size = 10011941, upload-time = "2026-08-27T16:33:41.287Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/46/6cf67cf6411885a1d6f7f6d801682f155536a85176d10b605e2ceffed8bd/ruff-0.16.5-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:eda58a5802de40e7ed5b32b64e0b32539338cc6fcd2c78f61e3ad6a0d79f51c3", size = 10204049, upload-time = "2026-08-27T16:33:44.056Z" },
+    { url = "https://files.pythonhosted.org/packages/46/fd/c8720ca7a090abf0c2fef4abe8a5ef6e5127ed15196d8886ff75a2b370e2/ruff-0.16.5-py3-none-macosx_11_0_arm64.whl", hash = "sha256:c5ae9a7b9a8875131f40f8fe967cc86abf899779efd663cb7ce3d572d01da7eb", size = 9809037, upload-time = "2026-08-27T16:33:46.257Z" },
+    { url = "https://files.pythonhosted.org/packages/43/45/a684caacdedaca180f52bacccc40bf0789d2c5a7c75f25324853e9eaedb5/ruff-0.16.5-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7b719b0a1f4d59710d283ab2965f621684a108a9e41da622e3b23f0326cd0025", size = 9964129, upload-time = "2026-08-27T16:33:48.352Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/f2/5d2bcdaca6b5b93d1b4dfc166cd2aebf7680143a1b38a28759df13a94d31/ruff-0.16.5-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:2298f2780ed1be0c5cb1361e32ab7b1467f3cce7dabe101d2210a314f2fe42e9", size = 9821518, upload-time = "2026-08-27T16:33:50.57Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/ff/011cce29accf9257d5974145b733fc653a37985ed6825413a3987cefbfe0/ruff-0.16.5-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:258f29035a2dd021e7861e631b227a5b3f14e50c1184c9a6a122c5f4576154d7", size = 10534835, upload-time = "2026-08-27T16:33:52.522Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/5a/f0cf109bada9bba0e96c90c21c9f9251803f57225c32d293327a03c710d6/ruff-0.16.5-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:b9a4f0432966834019c74d1b7e5c51224305d7713f3d7faf3e7451f1a3be3cde", size = 11252550, upload-time = "2026-08-27T16:33:54.521Z" },
+    { url = "https://files.pythonhosted.org/packages/63/4d/1d481aaea2046c6a7ed7c291f9004c669cce3c087b6b376ed5b08271e3fe/ruff-0.16.5-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:b5eb3a8c3d0ade9cea42b591fd530368e8798380e30e0a308b85a5cf718f09ea", size = 10777949, upload-time = "2026-08-27T16:33:56.88Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/34/ee245ca55f64443233034b3d02b03236b19242004281247c079390b7facd/ruff-0.16.5-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ef0f69e191a13a3c9816f63163c88790cb12cd157bbbb384e9c44745702ab105", size = 10311656, upload-time = "2026-08-27T16:33:59.12Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/4d/c33a333e341c0a2b96c715b52d89a606f5a34cd4ac493cd9b8d0187186b8/ruff-0.16.5-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:0eeab41fbea2c42f98dfb9822cdccda9d24ba38d49f6dc945b5c236d48f0ef29", size = 10532125, upload-time = "2026-08-27T16:34:01.166Z" },
+    { url = "https://files.pythonhosted.org/packages/30/e1/a64cef78b40192497bb98a27a8aa8f2c98ee9ee15bc97f7712d94ef32937/ruff-0.16.5-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:f0768e9df4300713fff30733c87575f68b6f1d8de41184e505b7fdd9c0c95eaf", size = 10097648, upload-time = "2026-08-27T16:34:03.16Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/4e/4cdc9ed3c3e109d2f71e62572a37457298d7bc7501ec3138babb7ed32bbd/ruff-0.16.5-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:95cc70cdc7aa80c338de356279d2adbeb2de0f520b9ecd8aba75b94e95e02f91", size = 9829344, upload-time = "2026-08-27T16:34:05.134Z" },
+    { url = "https://files.pythonhosted.org/packages/39/4a/31ed35ce31729955fc583ee0d176d6e784c1290cb0b0a75cb2134c1ab72a/ruff-0.16.5-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d185c8398ded1bfd91c0c2cb258346307571eccc473a8490af8c3977399c384a", size = 10277117, upload-time = "2026-08-27T16:34:07.425Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/a0/60356d86687b4b666d593df213f4dc3041750d024cb7bf2cfa81cfd65c2e/ruff-0.16.5-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:fb8e3a3c4c6a784150a7ced53b015f4b253fc2bf97a610886419ead64b4756ef", size = 10711653, upload-time = "2026-08-27T16:34:09.712Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/20/656d67f5b25ca9bda4e02b1de25867b2954e1d19e03648060f167ad0f4cc/ruff-0.16.5-py3-none-win32.whl", hash = "sha256:288b0a5f080492fe5635db849f9e2e84aa3cce7b7f0e955997d416c507c76a26", size = 10034250, upload-time = "2026-08-27T16:34:11.8Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/42/ee8e68a207b9127fcde6c3d7e197def432f346cb1af159e1fa14ca0d1cdc/ruff-0.16.5-py3-none-win_amd64.whl", hash = "sha256:ddc6385fb2137f616357ca03d6c74f4be987f80fed4008566b754f6032b8546f", size = 10516714, upload-time = "2026-08-27T16:34:13.963Z" },
+    { url = "https://files.pythonhosted.org/packages/73/e3/7df5a396e445b9ba49ce9a9437439a4d80042c61c0ade199abf8d16de1ac/ruff-0.16.5-py3-none-win_arm64.whl", hash = "sha256:a64abe90968719b851bb7cedffaa8753fbdbdadab483089682db623f3edc587e", size = 10391564, upload-time = "2026-08-27T16:34:16.064Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 概要

此 PR 向本项目引入了 ruff 格式化以及一个每天定时运行的 GitHub Actions 格式化工作流。

- 添加了 ruff 到开发依赖组中，开发者可通过 `uv sync --group dev` 进行安装。
- 添加了 VS Code 对 Python 文件的自动格式化配置，现在手动保存代码会自动在本地进行格式化了。
- 调教了 AGENTS.md 使其包含格式化的指引。
- GitHub Actions 格式化工作流 `format` 参照了现有的 `download_stats` 的写法，并且会在北京时间每天 7:00 运行一次。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新功能**
  - 新增自动化代码格式检查与修复流程，可按需或每日运行，并自动提交格式化变更。

- **改进**
  - 增加 Ruff 格式化与检查配置，统一 Python 代码风格。
  - 优化 VS Code 工作区设置，支持保存时自动格式化、修复和导入整理。
  - 增加推荐的 Python 与 Ruff 编辑器扩展。

- **文档**
  - 更新项目开发规范、环境配置及常用命令说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->