### PR TITLE
ci: 修复 Format 工作流依赖安全告警

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -24,7 +24,7 @@ jobs:
           python-version: "3.12"
 
       - name: install uv
-        run: 'pip install --only-binary :all: uv==0.10.9'
+        run: 'pip install --only-binary :all: uv==0.12.5'
 
       - name: install deps
         run: uv sync --locked --no-build --only-group dev

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -24,15 +24,15 @@ jobs:
           python-version: "3.12"
 
       - name: install uv
-        run: pip install uv
+        run: 'pip install --only-binary :all: uv==0.10.9'
 
       - name: install deps
-        run: uv sync --group dev
+        run: uv sync --locked --no-build --only-group dev
 
       - name: ruff check fix and format
         run: |
-          uv run ruff check --fix .
-          uv run ruff format .
+          uv run --locked --no-build --no-sync ruff check --fix .
+          uv run --locked --no-build --no-sync ruff format .
 
       - name: commit to branch
         id: commit


### PR DESCRIPTION
## 修改内容

- 固定 Format 工作流安装的 `uv` 版本，并仅允许二进制 wheel。
- 使用 `uv.lock` 且禁止构建源码包，仅同步 Ruff 所需的 `dev` 依赖组。
- Ruff 执行阶段禁止隐式同步，继续使用已锁定且已验证的环境。

## 验证

- `uv run --locked --with PyYAML python -c "import yaml; yaml.safe_load(open('.github/workflows/format.yml', encoding='utf-8')); print('YAML OK')"`
- `actionlint .github/workflows/format.yml`
- 使用 `uv 0.10.9` 执行 `uv sync --locked --no-build --only-group dev`
- 使用 `uv 0.10.9` 验证两条 `uv run --locked --no-build --no-sync ruff ...` 命令可执行

## 说明

- 解决 SonarCloud 在 Format 工作流中报告的 8 个 Major 漏洞。
- master 当前仍有既存 Ruff 告警和未格式化文件；本 PR 不扩大范围处理这些基线问题。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **维护**
  * 更新自动化格式检查流程所使用的工具版本，提升执行环境的稳定性。
  * 保持基于锁定配置的开发环境安装，并跳过不必要的构建步骤。
  * 继续在一致的工具环境中执行代码检查与格式化，确保结果更可靠。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->