### PR TITLE
ci: 更改格式化工作流所用的操作系统类型

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,7 +12,7 @@ permissions:
 jobs:
   format:
     if: ${{ github.repository_owner == 'AliceJump' }}
-    runs-on: ubuntu-latest
+    runs-on: windows-latest
 
     steps:
       - name: checkout
@@ -22,17 +22,18 @@ jobs:
         uses: actions/setup-python@v6
         with:
           python-version: "3.12"
+          cache: pip
 
       - name: install uv
-        run: 'pip install --only-binary :all: uv==0.12.5'
+        run: "pip install --only-binary :all: uv==0.12.5"
 
       - name: install deps
-        run: uv sync --locked --no-build --only-group dev
+        run: uv sync --locked --only-group dev
 
       - name: ruff check fix and format
         run: |
-          uv run --locked --no-build --no-sync ruff check --fix .
-          uv run --locked --no-build --no-sync ruff format .
+          uv run --locked ruff check --fix .
+          uv run --locked ruff format .
 
       - name: commit to branch
         id: commit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,10 +21,19 @@ dependencies = [
 ]
 
 [dependency-groups]
-dev = ["playwright>=1.55,<2", "polib>=1.2,<2", "pypinyin>=0.55,<1", "PyYAML>=6.0,<7", "ruff>=0.16,<1"]
+dev = [
+    "playwright>=1.55,<2",
+    "polib>=1.2,<2",
+    "pypinyin>=0.55,<1",
+    "PyYAML>=6.0,<7",
+    "ruff>=0.16,<1",
+]
 
 [tool.uv]
 package = false
+override-dependencies = [
+    "pywin32==311; sys_platform == 'win32'",
+] # Only Windows can install pywin32
 
 [tool.ruff]
 line-length = 120

--- a/uv.lock
+++ b/uv.lock
@@ -2,6 +2,9 @@ version = 1
 revision = 3
 requires-python = "==3.12.*"
 
+[manifest]
+overrides = [{ name = "pywin32", marker = "sys_platform == 'win32'", specifier = "==311" }]
+
 [[package]]
 name = "certifi"
 version = "2026.7.22"
@@ -258,7 +261,7 @@ dependencies = [
     { name = "pycaw" },
     { name = "pydirectinput" },
     { name = "pynput" },
-    { name = "pywin32" },
+    { name = "pywin32", marker = "sys_platform == 'win32'" },
     { name = "requests" },
     { name = "typing-extensions" },
 ]


### PR DESCRIPTION
## 概要

此 PR 是为了修复 Format 工作流运行失败的问题，参见 https://github.com/AliceJump/ok-end-field/actions/runs/33458856065/job/99704537033 。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改进**
  * 优化 Windows 环境下的自动格式检查与依赖安装流程。
  * 启用依赖缓存，提升相关检查任务的执行效率。
  * 针对 Windows 环境固定兼容的系统依赖版本，增强开发工具链稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->