### PR TITLE
fix: 修复 _has_detected_team_member 测试 StopIteration

### DIFF
--- a/tests/TestStateDrivenWaits.py
+++ b/tests/TestStateDrivenWaits.py
@@ -460,25 +460,30 @@ class TestStateDrivenWaits(unittest.TestCase):
 
     @patch("src.tasks.mixin.battle_mixin.detect_team_from_frame")
     def test_detected_team_member_rechecks_current_frame(self, detect_team):
-        detect_team.side_effect = [["?", "?"], ["余烬", "?"]]
+        # 第一次调用返回不匹配的队伍，之后每次返回匹配队伍
+        detect_team.side_effect = [
+            ["角色A", "角色B"],  # 不匹配 → matched_count 重置
+            ["余烬", "赵昭"],  # 匹配 → matched_count=1
+            ["余烬", "赵昭"],  # 匹配 → matched_count=2 → 返回 True
+        ]
 
         class StubTask:
             frame = np.zeros((10, 10, 3), dtype=np.uint8)
-            _battle_team = ["余烬", "?"]
+            _battle_team = ["余烬", "赵昭"]
 
             def next_frame(self):
                 return self.frame
 
             def active_time(self):
-                return 0
+                # 利用 detect_team 的调用次数模拟时间推进
+                return float(detect_team.call_count)
 
             def log_info(self, msg):
                 pass
 
         task = StubTask()
-        self.assertFalse(BattleMixin._has_detected_team_member(task))
         self.assertTrue(BattleMixin._has_detected_team_member(task))
-        self.assertEqual(detect_team.call_count, 2)
+        self.assertEqual(detect_team.call_count, 3)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## 问题

CI `test (3.12)` 在 `test_detected_team_member_rechecks_current_frame` 失败：

```
StopIteration
  File "tests/TestStateDrivenWaits.py", line 479
    self.assertFalse(BattleMixin._has_detected_team_member(task))
```

## 根因

`_has_detected_team_member` 引入了基于 `active_time()` 的超时循环后，测试未同步更新：

1. **`StubTask.active_time()` 永远返回 `0`** → `while` 循环永不会超时退出
2. **`battle_team = ["余烬", "?"]`** → 代码中 `not any(member == "?" ...)` 条件会排除含 `"?"` 的队伍，即使 `detect_team_from_frame` 返回完全相同的列表也不会匹配
3. mock 的 `side_effect` 只有 2 个值，循环第 3 次迭代时耗尽 → `StopIteration`

## 修复

- `battle_team` 改为不含 `"?"` 的真实队伍 `["余烬", "赵昭"]`
- `active_time()` 改为返回 `float(detect_team.call_count)` 使循环可正常超时退出
- `side_effect` 提供 3 个值：1 个不匹配 + 2 个连续匹配，验证完整流程

本地 302 项测试全部通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 更新团队成员检测相关测试，覆盖从队伍不匹配到连续两次匹配后成功的等待流程。
  * 增加对检测调用次数的验证，确保该流程执行三次。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->