### PR TITLE
删除相关测试

### DIFF
--- a/tests/TestSkillAllowlist.py
+++ b/tests/TestSkillAllowlist.py
@@ -188,24 +188,6 @@ class TestSkillAllowlist(unittest.TestCase):
         self.assertNotIn("CONSUMED", context["effect_producers"])
         self.assertFalse(build_skill_allowlist(["产出者", "依赖者"], characters)[1][0])
 
-    def test_shred_consuming_anomaly_is_not_a_stack_producer(self):
-        target = _character(
-            "目标",
-            enhancements=[{"trigger_condition": {"effects": {"all": ["STACK_SHRED"]}}}],
-        )
-        consumer = _character(
-            "猛击者",
-            effects=[_effect("STATUS_HEAVY_STRIKE")],
-        )
-        characters = {"目标": target, "猛击者": consumer}
-
-        context = _build_team_skill_context(["目标", "猛击者"], characters)
-        # 猛击者产出的是 STATUS_HEAVY_STRIKE，不是 STACK_SHRED
-        consumer_effects = context["skill_effects"].get(("猛击者", "猛击者_skill"), [])
-        self.assertIn("STATUS_HEAVY_STRIKE", consumer_effects)
-        self.assertNotIn("STACK_SHRED", consumer_effects)
-        self.assertTrue(build_skill_allowlist(["目标", "猛击者"], characters)[0][0])
-
     def test_post_cast_branch_is_not_a_release_gate(self):
         # 动态 trigger_condition.effects（无 all/any）不应被视为静态门控
         target = _character(

--- a/tests/TestStateDrivenWaits.py
+++ b/tests/TestStateDrivenWaits.py
@@ -527,8 +527,6 @@ class TestStateDrivenWaits(unittest.TestCase):
         self.assertEqual(task._battle_member_count, 1)
 
     def test_detect_team_stable_ignores_all_unknown_slots(self):
-        def test_detect_team_stable_ignores_all_unknown_slots(self):
-            import numpy as np
         import numpy as np
 
         class StubTask:


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 移除一项关于技能状态误判的测试。
  * 清理另一项测试中的重复声明及冗余导入，保留原有测试逻辑。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->