### PR TITLE
添加角色泰风巨兽的多语言名字

### DIFF
--- a/assets/lang/characters.json
+++ b/assets/lang/characters.json
@@ -1318,5 +1318,49 @@
     "vi_VN": {
       "string": "Liino"
     }
+  },
+  "ti_fu_luo_si": {
+    "zh_CN": {
+      "string": "提弗洛斯"
+    },
+    "zh_TW": {
+      "string": "提弗洛斯"
+    },
+    "en_US": {
+      "string": "Typhoeus"
+    },
+    "ja_JP": {
+      "string": "ティフォロス"
+    },
+    "ko_KR": {
+      "string": "티프로스"
+    },
+    "es_ES": {
+      "string": "Typhoeus"
+    },
+    "pt_BR": {
+      "string": "Typhoeus"
+    },
+    "de_DE": {
+      "string": "Typhoeus"
+    },
+    "fr_FR": {
+      "string": "Typhoeus"
+    },
+    "id_ID": {
+      "string": "Typhoeus"
+    },
+    "it_IT": {
+      "string": "Typhoeus"
+    },
+    "ru_RU": {
+      "string": "Тифея"
+    },
+    "th_TH": {
+      "string": "ไท​ฟี​อุส"
+    },
+    "vi_VN": {
+      "string": "Typhoeus"
+    }
   }
 }


### PR DESCRIPTION

<img width="1188" height="764" alt="image" src="https://github.com/user-attachments/assets/630d2c19-8a41-4408-b36e-7138a6e7d293" />
<img width="3224" height="767" alt="image" src="https://github.com/user-attachments/assets/094aa8ee-2fbb-47ae-8178-9153e8e035d5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新内容**
  - 新增角色“提弗洛斯”条目。
  - 补充简体中文、繁体中文、英语、日语、韩语、西班牙语、葡萄牙语、德语、法语、印度尼西亚语、意大利语、俄语、泰语和越南语名称。
  - 角色名称现可在上述语言环境中正确显示，提升多语言内容的一致性与完整性。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->