### PR TITLE
fix: 改善队伍识别逻辑，支持部分成员识别失败时继续处理

### DIFF
--- a/src/data/skill_allowlist.py
+++ b/src/data/skill_allowlist.py
@@ -459,6 +459,9 @@ def build_skill_allowlist(
     # ── 转换为输出格式 ──
     result: dict[int, tuple[bool, str]] = {}
     for idx, char_name in enumerate(team_members):
+        if char_name == "?":
+            result[idx] = (True, "")
+            continue
         char_data = characters.get(char_name)
         if not char_data:
             result[idx] = (True, "")

--- a/src/tasks/mixin/battle_mixin.py
+++ b/src/tasks/mixin/battle_mixin.py
@@ -248,7 +248,7 @@ class BattleMixin(BaseEfTask):
     # 终结技释放后延迟退出检查的时间（秒）
     ULT_EXIT_DELAY = 3.0
 
-    def use_ult(self, ult_sequence: str = None):
+    def use_ult(self, ult_sequence: str | None = None):
         """
         尝试释放终极技。
 
@@ -260,10 +260,7 @@ class BattleMixin(BaseEfTask):
                 True  : 成功释放
                 False : 未找到可释放技能
         """
-        if ult_sequence is None:
-            ults = ["1", "2", "3", "4"]
-        else:
-            ults = [ult_sequence]
+        ults = ["1", "2", "3", "4"] if ult_sequence is None else [ult_sequence]
 
         release_mode = self.get_battle_config(KEY_ULT_RELEASE_MODE, ULT_RELEASE_MODE_HOLD)
 
@@ -517,7 +514,9 @@ class BattleMixin(BaseEfTask):
                 continue
 
             current = self.detect_team(frame)
-            if current == ["?", "?", "?", "?"]:
+
+            # 无效识别：空结果，或者全部都是 ?
+            if not current or all(x == "?" for x in current):
                 last_result = []
                 streak = 0
             else:

--- a/src/tasks/onetime/AutoCombatLogic.py
+++ b/src/tasks/onetime/AutoCombatLogic.py
@@ -389,7 +389,7 @@ class AutoCombatLogic:
                 if _skill_allowlist_enabled:
                     try:
                         team, stable = task.detect_team_stable(deadline=_sleep_end)
-                        if stable and team and all(m != "?" for m in team):
+                        if stable and team and any(m != "?" for m in team):
                             skill_sequence = generate_skill_sequence(team)
                             task._battle_team, self.normal_skill_sequence = team, skill_sequence
                             task.log_info(f"初始等待期间识别到队伍: {team}")
@@ -454,7 +454,7 @@ class AutoCombatLogic:
                     self._team_detect_attempts += 1
                     try:
                         team, stable = task.detect_team_stable()
-                        if stable and team and all(m != "?" for m in team):
+                        if stable and team and any(m != "?" for m in team):
                             skill_sequence = generate_skill_sequence(team)
                             task._battle_team, self.normal_skill_sequence = team, skill_sequence
                             task.log_info(f"战斗中识别到队伍: {team}")


### PR DESCRIPTION
## 变更内容

- `detect_team_stable` 支持空结果和部分 `?` 成员的情况
- `skill_allowlist` 跳过 `?` 角色而非中止
- `AutoCombatLogic` 改为 `any()` 判断队伍有效性
- `use_ult` 参数类型注解修正为 `str | None`

## 背景

原逻辑在队伍识别中遇到空结果或部分成员无法识别时会完全放弃处理。新逻辑允许在部分成员识别成功时继续工作，提高鲁棒性。