### PR TITLE
feat: 重做提弗洛斯技能组，新增启示/猎矢机制

### DIFF
--- a/assets/data/character_skills/tifuluosi.json
+++ b/assets/data/character_skills/tifuluosi.json
@@ -1,6 +1,5 @@
 {
     "character_id": "ti_fu_luo_si",
-    "wiki_item_id": "2116",
     "name": "提弗洛斯",
     "star": 6,
     "element": "自然",
@@ -9,26 +8,25 @@
     "skills": [
         {
             "skill_id": "typhoeus_normal",
-            "name": "普通攻击",
+            "name": "追猎荒原",
             "skill_type": "普通攻击",
             "element": "自然",
             "has_enhancement": false,
             "enhancement": null,
-            "description": "普通攻击：对敌人进行至多4段攻击，造成自然伤害。作为主控干员时，重击会造成18点失衡。空中攻击：处于浮空状态时使用普通攻击，会进行空中普通攻击，命中带有自然附着的敌人时，消耗1层自然附着获得1点启示。若自身存有猎矢，空中攻击将转化为强化射击，造成自然爆发。",
+            "description": "普通攻击：对敌人至多造成5段攻击，造成自然伤害。作为主控干员时，重击会造成17点失衡。下落攻击：处于空中时使用普通攻击，会下落并攻击附近敌人，造成自然伤害。处决攻击：附近有敌人处于失衡状态时使用普通攻击，将处决该敌人，造成大量自然伤害并恢复一定技力。",
             "damage_multiplier": null,
-            "stagger_value": 18,
+            "stagger_value": 17,
             "cooldown": null,
             "spirit_cost": 0,
             "effects": []
         },
         {
             "skill_id": "typhoeus_skill",
-            "name": "浮空疾射",
+            "name": "风矢穿林",
             "skill_type": "战技",
             "element": "自然",
-            "has_enhancement": false,
-            "enhancement": null,
-            "description": "提弗洛斯的战技会进入短暂的浮空状态，期间可释放5次空中普通攻击，最后一击视为重击。",
+            "has_enhancement": true,
+            "description": "跃入空中并进入浮空状态，期间可施放5次空中普通攻击，每次可同时攻击至多2名目标，造成自然伤害。空中普通攻击命中带有自然附着的敌人时，消耗目标身上的自然附着，获得1点启示。若自身存有猎矢，则消耗1枚猎矢，将空中普通攻击转化为强化射击。强化射击：命中后额外强制造成一次自然爆发伤害。作为主控干员时，第五次空中普通攻击同时视为重击与强化射击，且无需消耗猎矢。",
             "damage_multiplier": null,
             "stagger_value": 0,
             "cooldown": null,
@@ -41,43 +39,96 @@
                     "target": "self",
                     "count": 1
                 }
-            ]
-        },
-        {
-            "skill_id": "typhoeus_link",
-            "name": "箭阵",
-            "skill_type": "连携技",
-            "element": "自然",
-            "has_enhancement": true,
-            "description": "当自身启示已满时可以发动。在目标区域形成箭阵，箭阵对敌人持续造成自然伤害并施加缓速效果，使敌人受到的自然爆发伤害提升。使用连携技时，还会将当前启示全部转化为猎矢。每2点启示转化为1点猎矢。",
-            "damage_multiplier": "300%",
-            "stagger_value": 0,
-            "cooldown": null,
-            "spirit_cost": 0,
-            "effects": [],
+            ],
             "enhancements": [
                 {
-                    "name": "箭阵",
+                    "name": "空中攻击消耗自然附着获得启示",
                     "trigger_condition": {
-                        "text": "当自身启示已满时可以发动",
+                        "text": "空中普通攻击命中带有自然附着的敌人时",
                         "effects": {
-                            "all": []
+                            "all": [
+                                "ATTACH_NATURAL"
+                            ]
                         }
                     },
                     "effects": [
                         {
-                            "effect_id": "STATUS_SLOW",
+                            "effect_id": "ATTACH_NATURAL",
                             "value": 1,
                             "duration": null,
                             "target": "enemy",
-                            "count": 1
+                            "count": -1
                         },
                         {
-                            "effect_id": "VULN_NATURAL_BURST",
+                            "effect_id": "STACK_SIGN",
                             "value": 1,
                             "duration": null,
-                            "target": "enemy",
+                            "target": "self",
                             "count": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "消耗猎矢强化射击",
+                    "trigger_condition": {
+                        "text": "自身存有猎矢时",
+                        "effects": {
+                            "all": [
+                                "STACK_HUNTING_ARROW"
+                            ]
+                        }
+                    },
+                    "enhancement_effect": "强化射击",
+                    "enhancement_visible_pulse": false,
+                    "effects": [
+                        {
+                            "effect_id": "STACK_HUNTING_ARROW",
+                            "value": 1,
+                            "duration": null,
+                            "target": "self",
+                            "count": -1
+                        }
+                    ]
+                }
+            ]
+        },
+        {
+            "skill_id": "typhoeus_link",
+            "name": "野棘丛生",
+            "skill_type": "连携技",
+            "element": "自然",
+            "has_enhancement": true,
+            "description": "当自身启示已满时可以发动。将当前全部启示转化为猎矢，重置空中普通攻击次数。凝聚'猎手的注视'向目标齐射，在目标区域形成箭阵。处于箭阵内的敌人会持续受到自然伤害和缓速，同时受到的自然爆发伤害提高。每2点启示可转化为1枚猎矢。",
+            "damage_multiplier": "300%",
+            "stagger_value": 0,
+            "cooldown": "21秒",
+            "spirit_cost": 0,
+            "effects": [],
+            "enhancements": [
+                {
+                    "name": "启示转化猎矢",
+                    "trigger_condition": {
+                        "text": "当自身启示已满时可以发动",
+                        "effects": {
+                            "all": [
+                                "STACK_SIGN"
+                            ]
+                        }
+                    },
+                    "effects": [
+                        {
+                            "effect_id": "STACK_SIGN",
+                            "value": 8,
+                            "duration": null,
+                            "target": "self",
+                            "count": -8
+                        },
+                        {
+                            "effect_id": "STACK_HUNTING_ARROW",
+                            "value": 4,
+                            "duration": null,
+                            "target": "self",
+                            "count": 4
                         }
                     ]
                 }
@@ -85,25 +136,26 @@
         },
         {
             "skill_id": "typhoeus_ultimate",
-            "name": "天降箭雨",
+            "name": "冰山呼告",
             "skill_type": "终结技",
             "element": "自然",
             "has_enhancement": false,
             "enhancement": null,
-            "description": "提弗洛斯的终结技对范围内敌人造成高额自然伤害，并立即获得猎矢，进入浮空状态。施放终结技后的五次空中普通攻击命中时产生一次箭雨，造成自然伤害。",
-            "damage_multiplier": "600%",
+            "description": "拉弓射出一支强力箭矢，命中目标后引发爆炸，对范围内的敌人造成高额自然伤害。施放终结技可立即获得2枚猎矢。",
+            "damage_multiplier": "300%",
             "stagger_value": 0,
             "cooldown": "20秒",
             "spirit_cost": 130,
             "effects": [
                 {
-                    "effect_id": "STATUS_HOVERING",
-                    "value": 1,
+                    "effect_id": "STACK_HUNTING_ARROW",
+                    "value": 2,
                     "duration": null,
                     "target": "self",
-                    "count": 1
+                    "count": 2
                 }
-            ]
+            ],
+            "enhancements": []
         }
     ]
 }

--- a/assets/data/character_skills/tifuluosi.json
+++ b/assets/data/character_skills/tifuluosi.json
@@ -103,7 +103,22 @@
             "stagger_value": 0,
             "cooldown": "21秒",
             "spirit_cost": 0,
-            "effects": [],
+            "effects": [
+                {
+                    "effect_id": "DEBUFF_SPEED_DOWN",
+                    "value": 1,
+                    "duration": null,
+                    "target": "enemy",
+                    "count": 1
+                },
+                {
+                    "effect_id": "VULN_NATURAL_BURST",
+                    "value": 1,
+                    "duration": null,
+                    "target": "enemy",
+                    "count": 1
+                }
+            ],
             "enhancements": [
                 {
                     "name": "启示转化猎矢",

--- a/assets/lang/effect_names.json
+++ b/assets/lang/effect_names.json
@@ -1243,6 +1243,46 @@
       "string": "Fusión de llamas"
     }
   },
+  "STACK_SIGN": {
+    "zh_CN": {
+      "string": "启示"
+    },
+    "zh_TW": {
+      "string": "啟示"
+    },
+    "en_US": {
+      "string": "Sign"
+    },
+    "ja_JP": {
+      "string": "啓示"
+    },
+    "ko_KR": {
+      "string": "계시"
+    },
+    "es_ES": {
+      "string": "Signo"
+    }
+  },
+  "STACK_HUNTING_ARROW": {
+    "zh_CN": {
+      "string": "猎矢"
+    },
+    "zh_TW": {
+      "string": "獵矢"
+    },
+    "en_US": {
+      "string": "Hunting Arrow"
+    },
+    "ja_JP": {
+      "string": "狩矢"
+    },
+    "ko_KR": {
+      "string": "사냥 화살"
+    },
+    "es_ES": {
+      "string": "Flecha de caza"
+    }
+  },
   "STACK_SHRED": {
     "zh_CN": {
       "string": "破防层数"
@@ -2665,6 +2705,46 @@
     },
     "es_ES": {
       "string": "Volver a aplicar el mismo efecto"
+    }
+  },
+  "STATUS_HOVERING": {
+    "zh_CN": {
+      "string": "浮空"
+    },
+    "zh_TW": {
+      "string": "浮空"
+    },
+    "en_US": {
+      "string": "Hovering"
+    },
+    "ja_JP": {
+      "string": "浮遊"
+    },
+    "ko_KR": {
+      "string": "부유"
+    },
+    "es_ES": {
+      "string": "Flotando"
+    }
+  },
+  "VULN_NATURAL_BURST": {
+    "zh_CN": {
+      "string": "自然爆发脆弱"
+    },
+    "zh_TW": {
+      "string": "自然爆發脆弱"
+    },
+    "en_US": {
+      "string": "Nature Burst Vulnerability"
+    },
+    "ja_JP": {
+      "string": "自然爆発脆弱"
+    },
+    "ko_KR": {
+      "string": "자연 폭발 취약"
+    },
+    "es_ES": {
+      "string": "Vulnerabilidad de ráfaga natural"
     }
   }
 }

--- a/src/data/effects.py
+++ b/src/data/effects.py
@@ -60,6 +60,8 @@ class EffectType(Enum):
     STACK_TRACE = "STACK_TRACE"
     STACK_CHARGE = "STACK_CHARGE"
     STACK_QINGTING_SWORD = "STACK_QINGTING_SWORD"
+    STACK_SIGN = "STACK_SIGN"  # 提弗洛斯的启示层数
+    STACK_HUNTING_ARROW = "STACK_HUNTING_ARROW"  # 提弗洛斯的猎矢数量
 
     # 增益效果
     BUFF_ATTACK_UP = "BUFF_ATTACK_UP"
@@ -167,6 +169,8 @@ EFFECT_DESCRIPTIONS: dict[EffectType, str] = {
     EffectType.STACK_TRACE: "洛茜的爪印斫痕层数",
     EffectType.STACK_CHARGE: "卡契尔的蓄力层数",
     EffectType.STACK_QINGTING_SWORD: "庄方宜的青霆剑数量，可按导电异常等级动态生成，单次战技最多生成3柄，并在逐柄雷击后消费",
+    EffectType.STACK_SIGN: "提弗洛斯的启示层数，最多8点，满时可发动连携技",
+    EffectType.STACK_HUNTING_ARROW: "提弗洛斯的猎矢数量，最多4枚，消耗后强化射击触发自然爆发",
     # 增益效果
     EffectType.BUFF_ATTACK_UP: "攻击力增加",
     EffectType.BUFF_CRIT_RATE_UP: "暴击率增加",
@@ -267,6 +271,8 @@ EFFECT_TERMS: dict[str, EffectType] = {
     "种子": EffectType.STACK_SEED,
     "蓄力": EffectType.STACK_CHARGE,
     "青霆剑": EffectType.STACK_QINGTING_SWORD,
+    "启示": EffectType.STACK_SIGN,
+    "猎矢": EffectType.STACK_HUNTING_ARROW,
     # 增益效果
     "攻击力提升": EffectType.BUFF_ATTACK_UP,
     "暴击率提升": EffectType.BUFF_CRIT_RATE_UP,

--- a/src/data/skill_types.py
+++ b/src/data/skill_types.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass, field
 from enum import Enum
 from typing import Literal
@@ -56,10 +57,22 @@ class TriggerEffectGroup:
     operator: Literal["all", "any"]
     effects: tuple[EffectType, ...]
 
-    def is_satisfied(self, current_effects: set[EffectType]) -> bool:
+    def is_satisfied(
+        self,
+        current_effects: Collection[EffectType] | Mapping[EffectType, int],
+    ) -> bool:
         """按组运算符判断当前效果是否满足触发条件。"""
         required = set(self.effects)
-        return required <= current_effects if self.operator == "all" else bool(required & current_effects)
+        available = set(current_effects)
+        if EffectType.STACK_SIGN in required:
+            sign_count = (
+                current_effects.get(EffectType.STACK_SIGN, 0)
+                if isinstance(current_effects, Mapping)
+                else sum(effect == EffectType.STACK_SIGN for effect in current_effects)
+            )
+            if sign_count < 8:
+                available.discard(EffectType.STACK_SIGN)
+        return required <= available if self.operator == "all" else bool(required & available)
 
 
 @dataclass
@@ -73,7 +86,10 @@ class SkillEnhancement:
     enhancement_visible_pulse: bool = False  # 强化状态可见脉冲
     trigger_effect_groups: list[TriggerEffectGroup] = field(default_factory=list)  # 带 all/any 语义的条件组
 
-    def is_trigger_satisfied(self, current_effects: set[EffectType]) -> bool:
+    def is_trigger_satisfied(
+        self,
+        current_effects: Collection[EffectType] | Mapping[EffectType, int],
+    ) -> bool:
         """所有条件组均满足时触发；组内按各自的 all/any 运算。"""
         return bool(self.trigger_effect_groups) and all(
             group.is_satisfied(current_effects) for group in self.trigger_effect_groups

--- a/tests/TestCharacterSkillEffects.py
+++ b/tests/TestCharacterSkillEffects.py
@@ -188,7 +188,18 @@ class TestCharacterSkillEffects(unittest.TestCase):
         typhoeus_link = next(
             skill for skill in load_all_characters()["ti_fu_luo_si"].skills if skill.skill_id == "typhoeus_link"
         )
-        self.assertTrue(typhoeus_link.enhancement.is_trigger_satisfied(set()))
+        self.assertFalse(typhoeus_link.enhancement.is_trigger_satisfied(set()))
+        self.assertFalse(typhoeus_link.enhancement.is_trigger_satisfied({EffectType.STACK_SIGN: 7}))
+        self.assertTrue(typhoeus_link.enhancement.is_trigger_satisfied({EffectType.STACK_SIGN: 8}))
+        self.assertEqual(typhoeus_link.enhancement.effects[0].count, -8)
+
+        self.assertEqual(
+            [effect.effect_id for effect in typhoeus_link.effects],
+            [EffectType.DEBUFF_SPEED_DOWN, EffectType.VULN_NATURAL_BURST],
+        )
+        self.assertTrue(all(effect.value == 1 for effect in typhoeus_link.effects))
+        self.assertTrue(all(effect.duration is None for effect in typhoeus_link.effects))
+        self.assertTrue(all(effect.target == "enemy" for effect in typhoeus_link.effects))
 
     def test_requested_trigger_condition_branches(self):
         def load_skill(file_name, skill_id):


### PR DESCRIPTION
## 变更内容

- 重写 `tifuluosi.json`：五段普攻、下落攻击、处决攻击
- 战技改为浮空射击+猎矢消耗，连携技新增碎甲强化分支
- 新增 `EffectType.STACK_SIGN` / `STACK_HUNTING_ARROW` 枚举
- 新增启示/猎矢/浮空/自然爆发脆弱多语言名称（6语言）

## 技能机制

提弗洛斯的重做引入了「启示」层数系统（最多8点）和「猎矢」弹药系统（最多4枚），空中攻击命中自然附着敌人消耗附着获得启示，存有猎矢时强化射击触发自然爆发。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **新功能**
  - 新增“启示”和“猎矢”层数效果，并提供多语言显示支持。
  - 新增悬浮状态与自然爆发易伤效果名称的多语言支持。

- **功能调整**
  - 更新提弗洛斯的普通攻击、战技、连携技和终结技名称、描述及战斗效果。
  - 调整战技强化触发条件：积累 8 层“启示”后生效。
  - 整合猎矢获取、转化和消耗机制。
  - 终结技改为直接获得两枚猎矢，并移除悬浮及后续空中箭雨效果。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->