### PR TITLE
fix: 更新安塔尔连携技磁暴试验场强化分支

### DIFF
--- a/assets/data/character_skills/antal.json
+++ b/assets/data/character_skills/antal.json
@@ -70,13 +70,13 @@
             "effects": [],
             "enhancements": [
                 {
-                    "name": "磁暴试验场·破防",
+                    "name": "磁暴试验场·猛击",
                     "trigger_condition": {
-                        "text": "当被聚焦的敌人进入破防状态时可以发动",
+                        "text": "当被聚焦的敌人进入猛击状态时可以发动",
                         "effects": {
                             "all": [
                                 "STATUS_FOCUS",
-                                "STATUS_SHRED"
+                                "STATUS_HEAVY_STRIKE"
                             ]
                         }
                     },
@@ -84,11 +84,13 @@
                         {
                             "effect_id": "TRIGGER_REPEAT_EFFECT",
                             "value": 1,
-                            "duration": null,
+                            "duration": "",
                             "target": "enemy",
                             "count": 1
                         }
-                    ]
+                    ],
+                    "enhancement_effect": "",
+                    "enhancement_visible_pulse": false
                 },
                 {
                     "name": "磁暴试验场·击飞",
@@ -148,6 +150,29 @@
                             "effect_id": "TRIGGER_REPEAT_EFFECT",
                             "value": 1,
                             "duration": null,
+                            "target": "enemy",
+                            "count": 1
+                        }
+                    ]
+                },
+                {
+                    "name": "磁暴试验场·碎甲",
+                    "trigger_condition": {
+                        "text": "当被聚焦的敌人进入碎甲状态时可以发动",
+                        "effects": {
+                            "all": [
+                                "STATUS_FOCUS",
+                                "STATUS_SHATTER"
+                            ]
+                        }
+                    },
+                    "enhancement_effect": "",
+                    "enhancement_visible_pulse": false,
+                    "effects": [
+                        {
+                            "effect_id": "TRIGGER_REPEAT_EFFECT",
+                            "value": 1,
+                            "duration": "",
                             "target": "enemy",
                             "count": 1
                         }


### PR DESCRIPTION
## 变更内容

- 磁暴试验场·破防分支改为猛击触发（`STATUS_SHRED` → `STATUS_HEAVY_STRIKE`）
- 新增磁暴试验场·碎甲强化分支（`STATUS_SHATTER`）
- 调整 `enhancement_effect` 和 `enhancement_visible_pulse` 字段

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 新增「磁暴试验场·碎甲」强化效果。
  * 更新「磁暴试验场」强化选项，新增对应的猛击触发效果与可见提示。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->