### PR TITLE
perf: 消除同一帧下重复的匹配计算逻辑

### DIFF
--- a/src/core/base_mixin/runtime_mixin.py
+++ b/src/core/base_mixin/runtime_mixin.py
@@ -916,16 +916,20 @@ class RuntimeMixin:
         start_time = self.active_time()
         last_frame = parse_box(self.next_frame(), box)
         stable_start = None
+        # 哈希只随新帧计算一次并滚动复用，避免上一帧的哈希每轮重复计算
+        last_hash = None
+        if method in ("phash", "dhash"):
+            from src.image.stability import hamming_distance, perceptual_hash
+
+            last_hash = perceptual_hash(last_frame, method=method)
 
         while True:
             current_frame = parse_box(self.next_frame(), box)
 
             if method in ("phash", "dhash"):
-                from src.image.stability import hamming_distance, perceptual_hash
-
-                h1 = perceptual_hash(last_frame, method=method)
                 h2 = perceptual_hash(current_frame, method=method)
-                is_stable = hamming_distance(h1, h2) <= threshold
+                is_stable = hamming_distance(last_hash, h2) <= threshold
+                last_hash = h2
 
             elif method == "pixel":
                 if last_frame.shape != current_frame.shape:

--- a/src/tasks/onetime/AutoCombatLogic.py
+++ b/src/tasks/onetime/AutoCombatLogic.py
@@ -78,9 +78,10 @@ class AutoCombatLogic:
     def _do_normal_combat_frame(self):
         """执行一帧普通战斗逻辑（非排轴模式 / normal_[n] 临时模式共用）。"""
         task = self.task
+
+        # 技能优先级：连携技 > 推荐技能 > 终结技
         if task.use_link_skill():
             return
-        # 推荐技能：优先级仅次于连携技，高于终结技
         if task.use_recommend_skill():
             return
         if task.use_ult():
@@ -95,7 +96,7 @@ class AutoCombatLogic:
         if self.normal_skill_index >= len(self.normal_skill_sequence):
             self.normal_skill_index = 0
 
-        current_points = task.get_skill_bar_count()
+        current_points = skill_count  # 同帧结果必然相同
         if current_points < 1:
             if task.use_ult():
                 return

--- a/src/tasks/trigger/AutoInteractionTask.py
+++ b/src/tasks/trigger/AutoInteractionTask.py
@@ -50,10 +50,15 @@ class AutoInteractionTask(BaseEfTask, TriggerTask):
                     self.click(result, after_sleep=0.4)
                     return
         if self.config.get("自动点击传送", True):
-            # 先普通匹配；未找到时再尝试一次轮廓（Canny）匹配，对按钮反色/主题变化不敏感
+            # 传送按钮只存在于地图界面：先用侧栏 in_map 特征确认界面，
+            # 未在地图界面时跳过匹配，避免每周期白跑全屏模板 + Canny 兜底
+            in_map_box = self.box_of_screen(0.027, 0.531, 0.051, 0.896)
             result = self.find_one(fL.transfer_go, frame=now)
-            if not result:
-                result = self.find_one(fL.transfer_go, frame=now, canny_lower=50, canny_higher=150, threshold=0.8)
             if result:
-                if self.find_one(fL.in_map, box=self.box_of_screen(0.027, 0.531, 0.051, 0.896), frame=now):
+                if self.find_one(fL.in_map, box=in_map_box, frame=now):
+                    self.click(result, after_sleep=0.4)
+            elif self.find_one(fL.in_map, box=in_map_box, frame=now):
+                # 未普通命中且已在地图界面：再尝试一次轮廓（Canny）匹配，对按钮反色/主题变化不敏感
+                result = self.find_one(fL.transfer_go, frame=now, canny_lower=50, canny_higher=150, threshold=0.8)
+                if result:
                     self.click(result, after_sleep=0.4)


### PR DESCRIPTION
## 概要

此 PR 消除了三处代码中存在的同一帧画面进行重复匹配计算的逻辑，以提升性能。

1. runtime mixin 中 `parse_box` 中的重复感知哈希计算。
2. 自动战斗中的同帧重复技能检测。
3. 自动点击传送中的一次冗余兜底检测。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **功能优化**
  - 调整自动战斗中的技能使用优先级：连携技优先于推荐技能，推荐技能优先于终结技。
  - 优化自动点击传送的识别流程，仅在确认处于地图界面时使用备用识别方式，提升操作准确性。

- **性能优化**
  - 减少界面稳定性检测中的重复图像计算，提升检测效率且不改变原有结果。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->