### PR TITLE
perf: 降低闪光比率函数调用频率

### DIFF
--- a/src/image/recommend_skill_detector.py
+++ b/src/image/recommend_skill_detector.py
@@ -28,6 +28,7 @@ import cv2
 import numpy as np
 
 __all__ = [
+    "PULSE_ON_RATIO",
     "RecommendSkillDetector",
     "get_recommend_skill_detector",
 ]
@@ -37,6 +38,7 @@ _WHITE_V_MIN = 200  # 明度下限：常态圆周 V≈118 被排除，脉冲白�
 _ANGLE_SAMPLES = 64  # 圆周角度采样数
 _SIGNAL_BAND = (0.93, 1.12)  # 中间信号层半径带（相对配置半径，含辉光外扩）
 _ON_RATIO = 0.80  # 白角占比确认阈值（定稿值；实测脉冲相位占比 0.59~0.94）
+PULSE_ON_RATIO = _ON_RATIO  # 公开确认阈值：供调用方复用当帧占比做全屏闪光判定，避免重复计算
 _OFF_FRAMES = 3  # 连续低于确认阈值帧数后复位（防止噪声占比卡在迟滞中区）
 
 
@@ -123,17 +125,16 @@ class RecommendSkillDetector:
         """
         return self._white_ratio(frame, cx_n, cy_n, r_n) >= _ON_RATIO
 
-    def detect(self, frame: np.ndarray, cx_n: float, cy_n: float, r_n: float, label: str) -> bool:
-        """检测指定按钮是否出现白色圆周脉冲上升沿。
+    def detect_ratio(self, white_ratio: float, label: str) -> bool:
+        """基于已计算的占比推进迟滞去抖状态机。
 
-        :param frame: BGR 截图帧
-        :param cx_n: 按钮中心 X（pixel / 宽）
-        :param cy_n: 按钮中心 Y（pixel / 高）
-        :param r_n: 按钮参考半径（pixel / 短边）
+        供同帧多用途场景（诊断 / 上升沿 / 闪光过滤共用一次占比计算）复用，
+        与 :meth:`detect` 的状态机语义完全一致。
+
+        :param white_ratio: 该区域当帧白色角度占比（0~1，见 :meth:`white_ratio`）
         :param label: 状态键（通常为区域名，如「批次1」）
         :return: 仅当本次调用构成新脉冲周期（上升沿）时为 True
         """
-        white_ratio = self._white_ratio(frame, cx_n, cy_n, r_n)
         with self._lock:
             track = self._tracks.setdefault(label, _Track())
             if white_ratio >= _ON_RATIO:
@@ -150,6 +151,18 @@ class RecommendSkillDetector:
                 if track.misses >= _OFF_FRAMES:
                     track.active = False
             return False
+
+    def detect(self, frame: np.ndarray, cx_n: float, cy_n: float, r_n: float, label: str) -> bool:
+        """检测指定按钮是否出现白色圆周脉冲上升沿。
+
+        :param frame: BGR 截图帧
+        :param cx_n: 按钮中心 X（pixel / 宽）
+        :param cy_n: 按钮中心 Y（pixel / 高）
+        :param r_n: 按钮参考半径（pixel / 短边）
+        :param label: 状态键（通常为区域名，如「批次1」）
+        :return: 仅当本次调用构成新脉冲周期（上升沿）时为 True
+        """
+        return self.detect_ratio(self._white_ratio(frame, cx_n, cy_n, r_n), label)
 
 
 _shared_lock = threading.Lock()

--- a/src/tasks/mixin/battle_mixin.py
+++ b/src/tasks/mixin/battle_mixin.py
@@ -46,7 +46,7 @@ from src.core.config_migration import legacy_battle_mode_to_bool
 from src.core.global_config_store import get_global_config
 from src.core.sequence_parser import parse_sequence
 from src.data.FeatureList import FeatureList as fL
-from src.image.recommend_skill_detector import get_recommend_skill_detector
+from src.image.recommend_skill_detector import PULSE_ON_RATIO, get_recommend_skill_detector
 from src.tasks.onetime.AutoCombatLogic import AutoCombatLogic
 
 # ── 编队识别：模块级常量与工具函数 ─────────────────────────────────────────
@@ -609,13 +609,19 @@ class BattleMixin(BaseEfTask):
             return False
 
         detector = get_recommend_skill_detector()
+        # 本帧各激活区域白色占比只计算一次，诊断 / 上升沿检测 / 闪光过滤共用
+        frame_ratios = {
+            str(region["label"]): detector.white_ratio(
+                frame, float(region["x"]), float(region["y"]), float(region["button_radius"])
+            )
+            for region in active_regions
+        }
         # 节流诊断：每 2 秒输出一次各区域白色占比，便于实战核对检测状态
         now = self.active_time()
         if now - getattr(self, "_recommend_last_diag", 0.0) >= 2.0:
             self._recommend_last_diag = now
             ratios = " ".join(
-                f"{region['label']}={detector.white_ratio(frame, float(region['x']), float(region['y']), float(region['button_radius'])):.2f}"
-                for region in active_regions
+                f"{region['label']}={frame_ratios[str(region['label'])]:.2f}" for region in active_regions
             )
             self.log_debug(f"推荐技能监测占比: {ratios}（人数 {member_count}）")
 
@@ -623,13 +629,7 @@ class BattleMixin(BaseEfTask):
         confirmed = []
         for slot, region in enumerate(active_regions, start=1):
             label = str(region["label"])
-            if detector.detect(
-                frame,
-                float(region["x"]),
-                float(region["y"]),
-                float(region["button_radius"]),
-                label,
-            ):
+            if detector.detect_ratio(frame_ratios[label], label):
                 confirmed.append((slot, region, label))
 
         # 全部激活区域（≥3 个）当前均为白色 = 大招演出/爆炸等全屏白闪，
@@ -637,13 +637,7 @@ class BattleMixin(BaseEfTask):
         # 判断：闪光前已 active 的标签不会产生上升沿，若只统计 confirmed
         # 会漏判闪光，导致其余区域误按技能键。
         if len(active_regions) >= 3 and all(
-            detector.is_pulsing(
-                frame,
-                float(region["x"]),
-                float(region["y"]),
-                float(region["button_radius"]),
-            )
-            for region in active_regions
+            frame_ratios[str(region["label"])] >= PULSE_ON_RATIO for region in active_regions
         ):
             labels = "、".join(str(region["label"]) for region in active_regions)
             self.log_info(f"推荐技能疑似全屏闪光，忽略本次命中: {labels}")


### PR DESCRIPTION
## 概要

此 PR 新增 `detect_ratio()` 并公开 `PULSE_ON_RATIO`，以提升性能；使得 use_recommend_skill 每帧只算 1 次占比，诊断/上升沿/闪光过滤共用（原来普通帧 1~2 次重算、闪光帧最多 4 次）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **改进**
  - 优化推荐技能提示的检测流程，基于白色区域占比进行判断，提升不同画面状态下的识别一致性。
  - 改进全屏闪光过滤逻辑，减少闪光效果对技能检测结果的干扰。
  - 保持原有的上升沿触发行为，并在识别到闪光时正确重置检测状态。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->