### PR TITLE
feat: 全局键位配置支持按账号独立覆盖

### DIFF
--- a/src/core/base_mixin/account_override_mixin.py
+++ b/src/core/base_mixin/account_override_mixin.py
@@ -41,6 +41,24 @@ class AccountOverrideMixin:
             return bool(self._raw_cfg_get("多账户独立配置", False))
         return True
 
+    def _account_override_for(self, config_name: str) -> dict:
+        """获取当前账号上下文对某个全局配置的覆盖字典。
+
+        仅在任务运行中、账号覆盖开关允许且存在账号上下文时返回覆盖值，
+        其余情况返回空 dict（等价于无覆盖，读取方走全局基值）。
+        """
+        if not getattr(self, "running", False):
+            return {}
+        if not self._is_account_override_enabled():
+            return {}
+
+        account_id = (getattr(self, "current_account_id", "") or "").strip()
+        account_name = (getattr(self, "current_user", "") or "").strip()
+        if not account_id and not account_name:
+            return {}
+
+        return get_account_task_overrides(account_id or account_name, config_name, account_name=account_name)
+
     @staticmethod
     def _coerce_override_value(base_value, override_value):
         if base_value is None or override_value is None:

--- a/src/core/base_mixin/runtime_mixin.py
+++ b/src/core/base_mixin/runtime_mixin.py
@@ -8,10 +8,12 @@ import numpy as np
 from ok import Box
 
 from src.config import config as app_config
+from src.core.global_config_store import KEY_CONFIG_NAME, get_global_config
 from src.data.FeatureList import FeatureList as fL
 from src.image.frame_processes import isolate_by_hsv_ranges
 from src.image.hsv_config import HSVRange as hR
 from src.interaction.Key import move_keys as send_move_keys
+from src.interaction.KeyConfig import KeyConfigManager
 from src.interaction.Mouse import (
     active_and_send_mouse_delta as send_mouse_delta,
 )
@@ -983,6 +985,23 @@ class RuntimeMixin:
 
         return super().info_set(key, value)
 
+    def _account_key_config(self) -> dict:
+        """全局键位配置叠加当前账号覆盖后的有效键位表（无账号上下文时为全局原值）。"""
+        base_config = get_global_config(KEY_CONFIG_NAME)
+        override = self._account_override_for(KEY_CONFIG_NAME)
+        if not override:
+            return base_config
+        effective = dict(base_config)
+        for key, value in override.items():
+            # 只应用已知键位，账号页之外的脏键不影响按键解析
+            if key in base_config:
+                effective[key] = self._coerce_override_value(base_config[key], value)
+        return effective
+
+    def _resolve_config_key(self, key: str, key_type: str) -> str:
+        """按当前账号上下文解析实际按键。"""
+        return KeyConfigManager(self._account_key_config()).resolve_key(key, key_type)
+
     def press_key(self, key: str, down_time: float = 0.02, after_sleep: float = 0, interval: int = -1):
         """
         按配置映射后的通用按键。
@@ -996,7 +1015,7 @@ class RuntimeMixin:
         Returns:
             Any: send_key 的返回值。
         """
-        actual_key = self.key_manager.resolve_key(key, "common")
+        actual_key = self._resolve_config_key(key, "common")
         return self.send_key(actual_key, interval=interval, down_time=down_time, after_sleep=after_sleep)
 
     def press_industry_key(self, key: str, down_time: float = 0.02, after_sleep: float = 0, interval: int = -1):
@@ -1012,7 +1031,7 @@ class RuntimeMixin:
         Returns:
             Any: send_key 的返回值。
         """
-        actual_key = self.key_manager.resolve_key(key, "industry")
+        actual_key = self._resolve_config_key(key, "industry")
         return self.send_key(actual_key, interval=interval, down_time=down_time, after_sleep=after_sleep)
 
     def press_combat_key(self, key: str, down_time: float = 0.02, after_sleep: float = 0, interval: int = -1):
@@ -1028,7 +1047,7 @@ class RuntimeMixin:
         Returns:
             Any: send_key 的返回值。
         """
-        actual_key = self.key_manager.resolve_key(key, "combat")
+        actual_key = self._resolve_config_key(key, "combat")
         return self.send_key(actual_key, interval=interval, down_time=down_time, after_sleep=after_sleep)
 
     def move_keys(self, keys, duration, need_back=False):

--- a/src/core/global_config_store.py
+++ b/src/core/global_config_store.py
@@ -71,9 +71,11 @@ ZIP_LINE_CONFIG_TYPE = {
     },
 }
 
+KEY_CONFIG_DEFAULTS = {**DEFAULT_COMMON_KEYS, **DEFAULT_INDUSTRY_KEYS, **DEFAULT_COMBAT_KEYS}
+
 key_config_option = ConfigOption(
     KEY_CONFIG_NAME,
-    {**DEFAULT_COMMON_KEYS, **DEFAULT_INDUSTRY_KEYS, **DEFAULT_COMBAT_KEYS},
+    KEY_CONFIG_DEFAULTS,
     description="游戏内快捷键配置",
     icon=Icons.Keyboard,
 )

--- a/src/gui/AccountConfigTab.py
+++ b/src/gui/AccountConfigTab.py
@@ -22,12 +22,15 @@ from qfluentwidgets import (
 )
 
 from src.core.global_config_store import (
+    KEY_CONFIG_DEFAULTS,
+    KEY_CONFIG_NAME,
     ZIP_LINE_CONFIG_DESCRIPTION,
     ZIP_LINE_CONFIG_NAME,
     ZIP_LINE_CONFIG_TYPE,
     ZIP_LINE_DEFAULT_CONFIG,
     get_global_config,
 )
+from src.icons import Icons
 from src.tasks.account.account_scope_store import (
     get_account_map_content,
     load_overrides,
@@ -49,6 +52,25 @@ class GlobalZipLineConfigProxy:
     config = get_global_config(ZIP_LINE_CONFIG_NAME)
     config_description = ZIP_LINE_CONFIG_DESCRIPTION
     config_type = ZIP_LINE_CONFIG_TYPE
+    account_config_blacklist = set()
+    account_config_whitelist = set()
+    account_config_defaults = {}
+    account_config_description = {}
+    account_config_type = {}
+
+
+class GlobalKeyConfigProxy:
+    """Expose the global hotkey schema in the per-account editor."""
+
+    name = "键位配置"
+    icon = Icons.Keyboard
+    account_override_name = KEY_CONFIG_NAME
+    support_multi_account = True
+    running = False
+    default_config = KEY_CONFIG_DEFAULTS
+    config = get_global_config(KEY_CONFIG_NAME)
+    config_description = {}
+    config_type = {}
     account_config_blacklist = set()
     account_config_whitelist = set()
     account_config_defaults = {}
@@ -456,6 +478,7 @@ class AccountConfigTab(CustomTab):
             seen.add(class_name)
             tasks.append(task)
         tasks.append(GlobalZipLineConfigProxy)
+        tasks.append(GlobalKeyConfigProxy)
         return tasks
 
     def refresh_from_source(self):

--- a/src/tasks/mixin/zip_line_mixin.py
+++ b/src/tasks/mixin/zip_line_mixin.py
@@ -9,7 +9,6 @@ from src.core.global_config_store import (
 )
 from src.core.sequence_parser import parse_int_sequence
 from src.image.hsv_config import HSVRange as hR
-from src.tasks.account.account_scope_store import get_account_task_overrides
 from src.tasks.mixin.navigation_mixin import NavigationMixin
 
 
@@ -103,21 +102,7 @@ class ZipLineMixin(NavigationMixin):
 
     def get_zip_line_config_value(self, key, default=None):
         base_value = self.zip_line_config.get(key, default)
-        if not getattr(self, "running", False):
-            return base_value
-        if hasattr(self, "_is_account_override_enabled") and not self._is_account_override_enabled():
-            return base_value
-
-        account_id = (getattr(self, "current_account_id", "") or "").strip()
-        account_name = (getattr(self, "current_user", "") or "").strip()
-        if not account_id and not account_name:
-            return base_value
-
-        override = get_account_task_overrides(
-            account_id or account_name,
-            ZIP_LINE_CONFIG_NAME,
-            account_name=account_name,
-        )
+        override = self._account_override_for(ZIP_LINE_CONFIG_NAME)
         if key not in override:
             return base_value
         return self._coerce_override_value(base_value, override[key])

--- a/tests/TestAccountKeyConfig.py
+++ b/tests/TestAccountKeyConfig.py
@@ -1,0 +1,165 @@
+import types
+import unittest
+from unittest.mock import patch
+
+from src.core.base_mixin.account_override_mixin import AccountOverrideMixin
+from src.core.base_mixin.runtime_mixin import RuntimeMixin
+from src.core.global_config_store import KEY_CONFIG_DEFAULTS, KEY_CONFIG_NAME
+
+
+class _Task(AccountOverrideMixin):
+    def __init__(self, running=True, independent=True, account_id="account-1", account_name="13800001111"):
+        self.config = {"多账户独立配置": independent}
+        self.running = running
+        self.current_account_id = account_id
+        self.current_user = account_name
+
+
+class _PressTask(RuntimeMixin, AccountOverrideMixin):
+    """只实现 press_key 依赖的最小接口，send_key 记录按键便于断言。"""
+
+    def __init__(self, running=True, independent=True, account_id="account-1", account_name="13800001111"):
+        self.sent_keys = []
+        self.config = {"多账户独立配置": independent}
+        self.running = running
+        self.current_account_id = account_id
+        self.current_user = account_name
+
+    def send_key(self, key, **kwargs):
+        self.sent_keys.append(key)
+        return key
+
+
+BASE_KEYS = dict(KEY_CONFIG_DEFAULTS)
+
+
+class TestAccountOverrideFor(unittest.TestCase):
+    @patch("src.core.base_mixin.account_override_mixin.get_account_task_overrides")
+    def test_returns_override_only_while_task_runs(self, get_overrides):
+        get_overrides.return_value = {"Dodge Key": "capslock"}
+        task = _Task(running=False)
+
+        self.assertEqual(task._account_override_for(KEY_CONFIG_NAME), {})
+
+        task.running = True
+        self.assertEqual(task._account_override_for(KEY_CONFIG_NAME), get_overrides.return_value)
+
+    @patch("src.core.base_mixin.account_override_mixin.get_account_task_overrides")
+    def test_respects_independent_config_switch(self, get_overrides):
+        get_overrides.return_value = {"a": "b"}
+
+        task = _Task(running=True, independent=False)
+        self.assertEqual(task._account_override_for(KEY_CONFIG_NAME), {})
+        get_overrides.assert_not_called()
+
+        task.config["多账户独立配置"] = True
+        self.assertEqual(task._account_override_for(KEY_CONFIG_NAME), {"a": "b"})
+
+    @patch("src.core.base_mixin.account_override_mixin.get_account_task_overrides")
+    def test_requires_account_context(self, get_overrides):
+        task = _Task(running=True, account_id="", account_name="")
+        self.assertEqual(task._account_override_for(KEY_CONFIG_NAME), {})
+        get_overrides.assert_not_called()
+
+
+class TestAccountKeyConfig(unittest.TestCase):
+    @patch("src.core.base_mixin.account_override_mixin.get_account_task_overrides")
+    @patch("src.core.base_mixin.runtime_mixin.get_global_config", return_value=BASE_KEYS)
+    def test_press_key_uses_account_override(self, _get_config, get_overrides):
+        get_overrides.return_value = {"Dodge Key": "capslock"}
+        task = _PressTask()
+
+        task.press_key("lshift")
+
+        self.assertEqual(task.sent_keys, ["capslock"])
+
+    @patch("src.core.base_mixin.account_override_mixin.get_account_task_overrides")
+    @patch("src.core.base_mixin.runtime_mixin.get_global_config", return_value=BASE_KEYS)
+    def test_press_key_without_override_keeps_global_value(self, _get_config, get_overrides):
+        get_overrides.return_value = {}
+        task = _PressTask()
+
+        task.press_key("lshift")
+        task.press_key("space")
+
+        self.assertEqual(task.sent_keys, ["lshift", "space"])
+
+    @patch("src.core.base_mixin.account_override_mixin.get_account_task_overrides")
+    @patch("src.core.base_mixin.runtime_mixin.get_global_config", return_value=BASE_KEYS)
+    def test_press_key_ignores_override_when_not_running(self, _get_config, get_overrides):
+        get_overrides.return_value = {"Dodge Key": "capslock"}
+        task = _PressTask(running=False)
+
+        task.press_key("lshift")
+
+        self.assertEqual(task.sent_keys, ["lshift"])
+        get_overrides.assert_not_called()
+
+    @patch("src.core.base_mixin.account_override_mixin.get_account_task_overrides")
+    @patch("src.core.base_mixin.runtime_mixin.get_global_config", return_value=BASE_KEYS)
+    def test_press_key_unmapped_key_passes_through(self, _get_config, get_overrides):
+        get_overrides.return_value = {"Dodge Key": "capslock"}
+        task = _PressTask()
+
+        # 移动键不在默认键位表中，即使存在账号覆盖也原样发送
+        task.press_key("w")
+
+        self.assertEqual(task.sent_keys, ["w"])
+
+    @patch("src.core.base_mixin.account_override_mixin.get_account_task_overrides")
+    @patch("src.core.base_mixin.runtime_mixin.get_global_config", return_value=BASE_KEYS)
+    def test_press_industry_and_combat_keys_use_account_override(self, _get_config, get_overrides):
+        get_overrides.return_value = {"Industry Plan Key": "g", "Link Skill Key": "q"}
+        task = _PressTask()
+
+        task.press_industry_key("t")
+        task.press_combat_key("e")
+
+        self.assertEqual(task.sent_keys, ["g", "q"])
+
+    @patch("src.core.base_mixin.account_override_mixin.get_account_task_overrides")
+    @patch("src.core.base_mixin.runtime_mixin.get_global_config", return_value=BASE_KEYS)
+    def test_account_key_config_filters_unknown_keys(self, _get_config, get_overrides):
+        get_overrides.return_value = {"不存在键": "zz", "Dodge Key": "capslock"}
+        task = _PressTask()
+
+        effective = task._account_key_config()
+
+        self.assertNotIn("不存在键", effective)
+        self.assertEqual(effective["Dodge Key"], "capslock")
+
+    @patch("src.core.base_mixin.account_override_mixin.get_account_task_overrides")
+    @patch("src.core.base_mixin.runtime_mixin.get_global_config", return_value=BASE_KEYS)
+    def test_account_key_config_without_override_returns_base(self, _get_config, get_overrides):
+        get_overrides.return_value = {}
+        task = _PressTask()
+
+        self.assertIs(task._account_key_config(), BASE_KEYS)
+
+
+class TestGlobalKeyConfigProxy(unittest.TestCase):
+    def test_proxy_exposes_hotkey_schema_for_account_editor(self):
+        from src.gui.AccountConfigTab import GlobalKeyConfigProxy
+
+        self.assertEqual(GlobalKeyConfigProxy.account_override_name, KEY_CONFIG_NAME)
+        self.assertEqual(GlobalKeyConfigProxy.name, "键位配置")
+        self.assertTrue(GlobalKeyConfigProxy.support_multi_account)
+        self.assertEqual(GlobalKeyConfigProxy.default_config, KEY_CONFIG_DEFAULTS)
+
+    def test_collect_tasks_includes_global_proxies(self):
+        from src.gui.AccountConfigTab import AccountConfigTab, GlobalKeyConfigProxy, GlobalZipLineConfigProxy
+
+        class _Executor:
+            def __init__(self):
+                self.onetime_tasks = []
+                self.trigger_tasks = []
+
+        stub = types.SimpleNamespace(executor=_Executor())
+        tasks = AccountConfigTab._collect_tasks(stub)
+
+        self.assertIn(GlobalZipLineConfigProxy, tasks)
+        self.assertIn(GlobalKeyConfigProxy, tasks)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概要
- 账号配置页新增「键位配置」项，按账号保存键位完整快照；存储沿用 `account_scoped_overrides.json`（`Game Hotkey Config` 命名空间），键位此前从未按账号存储，无需迁移
- `press_key` / `press_industry_key` / `press_combat_key` 运行时按当前账号解析实际按键；任务未运行、「多账户独立配置」关闭或无账号上下文时回退全局键位
- 从滑索覆盖读取中提取共享方法 `AccountOverrideMixin._account_override_for`，滑索配置与键位配置复用同一套账号覆盖门控（running + 开关 + 账号上下文）
- 「键位配置」名称复用全局配置页既有词条，各语言 ok.po 已有翻译，无新增 i18n

## 验证
- 新增 `TestAccountKeyConfig`（13 用例）：覆盖门控、三类按键账号解析、未映射键直通、脏键过滤、代理注册
- 标准测试套件通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新功能**
  * 支持为不同账号设置独立的快捷键配置。
  * 账号配置界面现可查看和编辑全局快捷键设置，并支持账号级覆盖。
  * 运行任务时优先使用当前账号的快捷键；未设置覆盖时自动使用全局配置。
  * 支持通用、行业和战斗等快捷键类型的统一配置管理。

* **测试**
  * 增加账号级快捷键覆盖、配置回退及界面展示相关测试。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->