### PR TITLE
perf: 消除全局/账号配置页首次切换卡顿

### DIFF
--- a/src/gui/AccountConfigTab.py
+++ b/src/gui/AccountConfigTab.py
@@ -8,6 +8,7 @@ from ok.gui.Communicate import communicate
 from ok.gui.tasks.ConfigCard import ConfigCard, og
 from ok.gui.tasks.LabelAndWidget import LabelAndWidget
 from ok.gui.widget.CustomTab import CustomTab
+from PySide6.QtCore import QTimer
 from PySide6.QtWidgets import QHBoxLayout, QVBoxLayout, QWidget
 from qfluentwidgets import (
     BodyLabel,
@@ -77,10 +78,15 @@ class AccountConfigTab(CustomTab):
 
     ALWAYS_HIDDEN_CONFIG_KEYS = {"多账户模式", "多账户独立配置", "账号列表"}
 
+    # 启动后空闲预热：提前完成账号页首屏构建，消除首次切换到本页的卡顿。
+    # 与 GlobalConfigTab.PREBUILD_DELAY_MS 错开，避免两个页面的构建负载叠加。
+    PREBUILD_DELAY_MS = 4500
+
     def __init__(self):
         super().__init__()
         self._loaded_once = False
         self._building = False
+        QTimer.singleShot(self.PREBUILD_DELAY_MS, self._prewarm_refresh)
 
         self.overrides_data: dict[str, Any] = {"accounts": {}}
         self.task_map: dict[str, Any] = {}
@@ -131,9 +137,19 @@ class AccountConfigTab(CustomTab):
         super().showEvent(event)
         if not self._loaded_once and self.executor is not None:
             self._loaded_once = True
-            self.refresh_from_source()
+            # 首次加载：选择器先立即就绪，重的编辑卡片渲染延后一拍，
+            # 保证切换到本页瞬间不被阻塞。
+            self.refresh_from_source(defer_render=True)
         elif self.executor is not None:
             self.sync_from_source()
+
+    def _prewarm_refresh(self):
+        """启动空闲时预热账号页首屏，效果等同首次 showEvent 的加载。"""
+        if self._loaded_once or self.executor is None:
+            # executor 未注入（预热早于 MainWindow 初始化）时留待首次 showEvent 处理
+            return
+        self._loaded_once = True
+        self.refresh_from_source()
 
     def sync_from_source(self):
         """Synchronize account configuration from the source without rebuilding task list."""
@@ -458,7 +474,7 @@ class AccountConfigTab(CustomTab):
         tasks.append(GlobalZipLineConfigProxy)
         return tasks
 
-    def refresh_from_source(self):
+    def refresh_from_source(self, defer_render: bool = False):
         """Fully refresh account configuration and task list from source data."""
         if not self._ensure_executor():
             return
@@ -473,8 +489,13 @@ class AccountConfigTab(CustomTab):
 
             self.rebuild_account_selector(keep_selection=False)
             self.rebuild_task_selector(keep_selection=False)
-            self.load_current_map_content()
-            self.render_task_editor()
+
+            if defer_render:
+                # 编辑卡片构建较重（数百个控件），放到下一轮事件循环构建
+                QTimer.singleShot(0, self._finish_deferred_refresh)
+            else:
+                self.load_current_map_content()
+                self.render_task_editor()
 
             if not tasks:
                 self._set_status(og.app.tr("未找到 support_multi_account=True 的任务"))
@@ -482,6 +503,11 @@ class AccountConfigTab(CustomTab):
                 self._set_status(og.app.tr("已刷新账号与任务配置（账号页账号列表与任务账号列表独立）"))
         finally:
             self._building = False
+
+    def _finish_deferred_refresh(self):
+        """完成 refresh_from_source(defer_render=True) 延后的重渲染部分。"""
+        self.load_current_map_content()
+        self.render_task_editor()
 
     def save_base_settings(self):
         """Save the account list and synchronize account registry."""

--- a/src/gui/AccountConfigTab.py
+++ b/src/gui/AccountConfigTab.py
@@ -86,7 +86,7 @@ class AccountConfigTab(CustomTab):
         super().__init__()
         self._loaded_once = False
         self._building = False
-        QTimer.singleShot(self.PREBUILD_DELAY_MS, self._prewarm_refresh)
+        QTimer.singleShot(self.PREBUILD_DELAY_MS, self, self._prewarm_refresh)
 
         self.overrides_data: dict[str, Any] = {"accounts": {}}
         self.task_map: dict[str, Any] = {}
@@ -492,7 +492,7 @@ class AccountConfigTab(CustomTab):
 
             if defer_render:
                 # 编辑卡片构建较重（数百个控件），放到下一轮事件循环构建
-                QTimer.singleShot(0, self._finish_deferred_refresh)
+                QTimer.singleShot(0, self, self._finish_deferred_refresh)
             else:
                 self.load_current_map_content()
                 self.render_task_editor()

--- a/src/gui/GlobalConfigTab.py
+++ b/src/gui/GlobalConfigTab.py
@@ -1,5 +1,6 @@
 from ok.gui.tasks.ConfigCard import ConfigCard
 from ok.gui.widget.CustomTab import CustomTab
+from PySide6.QtCore import QTimer
 from qfluentwidgets import FluentIcon, NavigationItemPosition
 
 from src.core.BattleConfig import BATTLE_CONFIG_NAME
@@ -12,8 +13,18 @@ GLOBAL_CONFIG_GROUPS = {
     "滑索配置": [ZIP_LINE_CONFIG_NAME],
 }
 
+# 启动后空闲预热：在用户点进本页之前把配置卡片建好，消除首次切换的卡顿。
+# 事件循环空闲后才会触发，不影响启动速度。
+PREBUILD_DELAY_MS = 3000
+
 
 class GlobalConfigTab(CustomTab):
+    def __init__(self):
+        super().__init__()
+        self._pending_cards = []
+        self._build_scheduled = False
+        QTimer.singleShot(PREBUILD_DELAY_MS, self._prewarm_build)
+
     @property
     def name(self):
         # MainWindow 会对 tab 的 name 统一调用 self.app.tr(name)，
@@ -35,12 +46,23 @@ class GlobalConfigTab(CustomTab):
 
     def showEvent(self, event):
         super().showEvent(event)
-        if self.vBoxLayout.count() == 0:
-            self._build_cards()
+        self._schedule_build()
 
-    def _build_cards(self):
+    def _prewarm_build(self):
+        self._schedule_build()
+
+    def _schedule_build(self):
+        """只排程一次；卡片逐个在事件循环空闲时构建，切换到本页不再被阻塞。"""
+        if self._build_scheduled:
+            return
+        self._build_scheduled = True
+        self._pending_cards = self._collect_cards()
+        QTimer.singleShot(0, self._build_next_card)
+
+    def _collect_cards(self):
         visible_configs = {name: (config, option) for name, config, option in get_all_visible_configs()}
         shown = set()
+        cards = []
         for group_name, config_names in GLOBAL_CONFIG_GROUPS.items():
             for config_name in config_names:
                 config_and_option = visible_configs.get(config_name)
@@ -48,32 +70,30 @@ class GlobalConfigTab(CustomTab):
                     continue
                 config, option = config_and_option
                 shown.add(config_name)
-                card = ConfigCard(
-                    None,
-                    group_name,
-                    config,
-                    option.description,
-                    option.default_config,
-                    option.config_description,
-                    option.config_type,
-                    option.icon,
-                )
-                # 标题即分组名（如「滑索配置」），ConfigCard 构造时已用 group_name 作为卡片标题
-                self.add_widget(card)
+                cards.append((group_name, config, option))
 
         for config_name, (config, option) in visible_configs.items():
             if config_name in shown:
                 continue
-            group_name = "其他配置"
-            card = ConfigCard(
-                None,
-                group_name,
-                config,
-                option.description,
-                option.default_config,
-                option.config_description,
-                option.config_type,
-                option.icon,
-            )
-            # 标题即分组名（如「滑索配置」），ConfigCard 构造时已用 group_name 作为卡片标题
-            self.add_widget(card)
+            cards.append(("其他配置", config, option))
+        return cards
+
+    def _build_next_card(self):
+        if not self._pending_cards:
+            return
+        group_name, config, option = self._pending_cards.pop(0)
+        card = ConfigCard(
+            None,
+            group_name,
+            config,
+            option.description,
+            option.default_config,
+            option.config_description,
+            option.config_type,
+            option.icon,
+        )
+        # 标题即分组名（如「滑索配置」），ConfigCard 构造时已用 group_name 作为卡片标题
+        self.add_widget(card)
+        if self._pending_cards:
+            # 每次事件循环只构建一张卡片，构建间隙保持界面响应
+            QTimer.singleShot(0, self._build_next_card)

--- a/src/gui/GlobalConfigTab.py
+++ b/src/gui/GlobalConfigTab.py
@@ -23,7 +23,7 @@ class GlobalConfigTab(CustomTab):
         super().__init__()
         self._pending_cards = []
         self._build_scheduled = False
-        QTimer.singleShot(PREBUILD_DELAY_MS, self._prewarm_build)
+        QTimer.singleShot(PREBUILD_DELAY_MS, self, self._prewarm_build)
 
     @property
     def name(self):
@@ -57,7 +57,7 @@ class GlobalConfigTab(CustomTab):
             return
         self._build_scheduled = True
         self._pending_cards = self._collect_cards()
-        QTimer.singleShot(0, self._build_next_card)
+        QTimer.singleShot(0, self, self._build_next_card)
 
     def _collect_cards(self):
         visible_configs = {name: (config, option) for name, config, option in get_all_visible_configs()}
@@ -96,4 +96,4 @@ class GlobalConfigTab(CustomTab):
         self.add_widget(card)
         if self._pending_cards:
             # 每次事件循环只构建一张卡片，构建间隙保持界面响应
-            QTimer.singleShot(0, self._build_next_card)
+            QTimer.singleShot(0, self, self._build_next_card)

--- a/tests/TestConfigTabPrewarm.py
+++ b/tests/TestConfigTabPrewarm.py
@@ -1,7 +1,9 @@
 import contextlib
+import copy
 import os
 import time
 import unittest
+import unittest.mock
 
 os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
 
@@ -65,7 +67,17 @@ class TabTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.app = QApplication.instance() or QApplication([])
+        cls._had_og_app = hasattr(og, "app")
+        cls._previous_og_app = getattr(og, "app", None)
         og.app = _FakeApp()
+
+    @classmethod
+    def tearDownClass(cls):
+        # 恢复 og.app，避免 _FakeApp 泄漏到套件中后续的其他用例
+        if cls._had_og_app:
+            og.app = cls._previous_og_app
+        else:
+            delattr(og, "app")
 
     def tearDown(self):
         _process_events(self.app)
@@ -121,7 +133,27 @@ class TestGlobalConfigTabBuild(TabTestCase):
         self.assertEqual(tab.vBoxLayout.count(), 5)
 
 
+_ACCOUNT_STORE = {
+    # 账号覆盖存储是 gitignore 的运行时文件（configs/account_scoped_overrides.json），
+    # 测试必须注入固定数据，不能依赖本机是否登录过账号。
+    "account_list_text": "tester_a\ntester_b\n",
+    "account_registry": {},
+    "accounts": {},
+    "map_contents": {},
+}
+
+
 class TestAccountConfigTabPrewarm(TabTestCase):
+    @classmethod
+    def setUpClass(cls):
+        super().setUpClass()
+        patcher = unittest.mock.patch(
+            "src.gui.AccountConfigTab.load_overrides",
+            lambda force=False: copy.deepcopy(_ACCOUNT_STORE),
+        )
+        patcher.start()
+        cls.addClassCleanup(patcher.stop)
+
     def _new_tab(self, with_executor=True):
         tab = AccountConfigTab()
         if with_executor:
@@ -135,7 +167,8 @@ class TestAccountConfigTabPrewarm(TabTestCase):
 
         self.assertTrue(tab._loaded_once)
         items = [tab.task_selector.itemText(i) for i in range(tab.task_selector.count())]
-        self.assertTrue(any("Game Hotkey Config" in item for item in items), "任务选择器应包含键位配置代理")
+        # 本 PR 的账号页仅含滑索代理；键位配置代理由 feat/account-scoped-key-config 引入
+        self.assertTrue(any("Zip Line Config" in item for item in items), "任务选择器应包含滑索配置代理")
 
     def test_prewarm_skipped_without_executor(self):
         tab = self._new_tab(with_executor=False)

--- a/tests/TestConfigTabPrewarm.py
+++ b/tests/TestConfigTabPrewarm.py
@@ -1,0 +1,171 @@
+import contextlib
+import os
+import time
+import unittest
+
+os.environ.setdefault("QT_QPA_PLATFORM", "offscreen")
+
+from PySide6.QtWidgets import QApplication
+
+from src.patches.conditional_rotation_patch import install_conditional_rotation_patch
+
+# 必须先于 ConfigCard 导入（config_widget 为导入时绑定）。
+# 只安装本文件需要的补丁，不装 startup_patches 全量，
+# 避免污染后续用例的全局 ctypes / 模块状态。
+install_conditional_rotation_patch()
+
+import sys as _sys  # noqa: E402
+
+import ok.gui.tasks.ConfigItemFactory as _factory  # noqa: E402
+
+# 套件中更早的用例可能已导入 ConfigCard（其 config_widget 引用绑定于补丁安装前），
+# 强制同步为补丁后的函数，保证 Battle Config 卡片（cond_sequence_editor 类型）可构建。
+for _name in ("ok.ui.qt.tasks.ConfigCard", "ok.gui.tasks.ConfigCard"):
+    _mod = _sys.modules.get(_name)
+    if _mod is not None:
+        _mod.config_widget = _factory.config_widget
+
+from ok import og  # noqa: E402
+
+from src.gui.AccountConfigTab import AccountConfigTab  # noqa: E402
+from src.gui.GlobalConfigTab import GlobalConfigTab  # noqa: E402
+
+
+class _FakeApp:
+    @staticmethod
+    def tr(message, *args):
+        return message
+
+
+class _Executor:
+    def __init__(self):
+        self.onetime_tasks = []
+        self.trigger_tasks = []
+
+
+def _process_events(app):
+    """processEvents，容忍套件中其他用例遗留的已删除控件事件。"""
+    with contextlib.suppress(RuntimeError):
+        app.processEvents()
+
+
+def _drain_pending(app, tab, timeout=5.0):
+    """推进事件循环直到延迟构建任务排空。"""
+    deadline = time.monotonic() + timeout
+    while getattr(tab, "_pending_cards", None) and time.monotonic() < deadline:
+        _process_events(app)
+    _process_events(app)
+
+
+class TabTestCase(unittest.TestCase):
+    """公共基类：共享 QApplication 并在用例结束后清理 tab，避免事件残留。"""
+
+    app = None
+
+    @classmethod
+    def setUpClass(cls):
+        cls.app = QApplication.instance() or QApplication([])
+        og.app = _FakeApp()
+
+    def tearDown(self):
+        _process_events(self.app)
+
+
+def _register_tab_cleanup(test, tab):
+    test.addCleanup(lambda: _dispose_tab(test, tab))
+
+
+def _dispose_tab(test, tab):
+    try:
+        tab.hide()
+        tab.close()
+        tab.deleteLater()
+    except RuntimeError:
+        return
+    _process_events(test.app)
+
+
+class TestGlobalConfigTabBuild(TabTestCase):
+    def _new_tab(self):
+        tab = GlobalConfigTab()
+        _register_tab_cleanup(self, tab)
+        return tab
+
+    def test_show_event_defers_card_building(self):
+        """首次切换到全局配置页：瞬间展示，卡片在后续事件循环逐张构建。"""
+        tab = self._new_tab()
+        tab.show()
+        self.assertEqual(tab.vBoxLayout.count(), 0, "showEvent 应立即返回，不构建卡片")
+        self.assertTrue(tab._build_scheduled)
+
+        _drain_pending(self.app, tab)
+        self.assertEqual(tab._pending_cards, [])
+        self.assertEqual(tab.vBoxLayout.count(), 5, "应构建全部 5 张配置卡片")
+
+    def test_build_only_scheduled_once(self):
+        tab = self._new_tab()
+        tab.show()
+        _drain_pending(self.app, tab)
+        count = tab.vBoxLayout.count()
+
+        tab.show()  # 重复 showEvent 不应再次构建
+        _process_events(self.app)
+        self.assertEqual(tab.vBoxLayout.count(), count)
+        self.assertEqual(tab._pending_cards, [])
+
+    def test_prewarm_builds_before_show(self):
+        """启动空闲预热：未展示过 tab 时也能提前完成构建。"""
+        tab = self._new_tab()
+        tab._prewarm_build()
+        _drain_pending(self.app, tab)
+        self.assertEqual(tab.vBoxLayout.count(), 5)
+
+
+class TestAccountConfigTabPrewarm(TabTestCase):
+    def _new_tab(self, with_executor=True):
+        tab = AccountConfigTab()
+        if with_executor:
+            tab.executor = _Executor()
+        _register_tab_cleanup(self, tab)
+        return tab
+
+    def test_prewarm_populates_and_marks_loaded(self):
+        tab = self._new_tab()
+        tab._prewarm_refresh()
+
+        self.assertTrue(tab._loaded_once)
+        items = [tab.task_selector.itemText(i) for i in range(tab.task_selector.count())]
+        self.assertTrue(any("Game Hotkey Config" in item for item in items), "任务选择器应包含键位配置代理")
+
+    def test_prewarm_skipped_without_executor(self):
+        tab = self._new_tab(with_executor=False)
+        tab._prewarm_refresh()
+        self.assertFalse(tab._loaded_once, "executor 未注入时应留待首次 showEvent")
+
+    def test_first_show_defers_editor_render(self):
+        """首次切换到账号页：选择器立即就绪，编辑卡片延后一拍构建。"""
+        tab = self._new_tab()
+        tab.show()
+
+        self.assertTrue(tab._loaded_once)
+        self.assertGreater(tab.task_selector.count(), 0, "任务选择器应在 showEvent 内同步就绪")
+        self.assertIsNone(tab.current_task, "编辑卡片应延后构建")
+
+        deadline = time.monotonic() + 5
+        while tab.current_task is None and time.monotonic() < deadline:
+            _process_events(self.app)
+        self.assertIsNotNone(tab.current_task, "事件循环推进后编辑卡片应完成构建")
+
+    def test_repeat_show_uses_cheap_sync(self):
+        tab = self._new_tab()
+        tab.show()
+        deadline = time.monotonic() + 5
+        while tab.current_task is None and time.monotonic() < deadline:
+            _process_events(self.app)
+
+        tab.show()  # 二次展示走 sync_from_source，不触发 deferred 队列
+        self.assertIsNotNone(tab.current_task)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 背景
两个自定义 tab 的重内容都在首次 showEvent 时同步构建。离屏实测：全局配置页首次切换冻结约 715ms（战斗/键位/滑索三张卡片各约 0.2s），账号配置页约 244ms；配置文件读取（get_all_visible_configs / load_overrides）均为毫秒级，瓶颈在 ConfigCard 一次性控件构建。

## 概要
- 全局配置页：ConfigCard 改为逐张异步构建，每张之间让出事件循环，切换立即响应
- 全局/账号页：启动后空闲预热（3s / 4.5s 错峰，事件循环空闲才触发，不影响启动速度），正常点入时内容已就绪
- 账号页首次展示：选择器在 showEvent 内同步就绪，编辑卡片渲染延后一拍；二次及以后展示仍走原有廉价 sync 路径（实测 ~5ms）

## 验证
- 离屏实测：全局页 showEvent 响应 715ms → 21ms（卡片分 5 拍，单拍最大 161ms）；账号页 244ms → 28ms；二次切换 0ms
- 新增 `TestConfigTabPrewarm`（7 用例：延迟构建、只构建一次、预热、首屏渲染延后、二次同步）
- 标准测试套件 333 用例全部通过


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **性能改进**
  * 优化配置页面加载流程，优先显示账号、任务等基础信息，较重内容改为延迟渲染。
  * 配置卡片改为分批、异步构建，减少首次打开页面时的等待和卡顿。
  * 增加启动后的后台预热，提升后续访问配置页面的响应速度。
  * 优化页面重复打开体验，避免重复构建已加载的配置内容。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->