### PR TITLE
fix: 修复评审等待脚本的 PowerShell 5.1 兼容与 gh --slurp 失效

### DIFF
--- a/.agents/skills/ok-script-pr-review/SKILL.md
+++ b/.agents/skills/ok-script-pr-review/SKILL.md
@@ -122,3 +122,4 @@ gh api graphql -f query='mutation { resolveReviewThread(input: {threadId: "<thre
 - A review comment id (`pulls/comments/<id>`) is NOT the same as a thread id; use the GraphQL `reviewThreads` listing to map them.
 - `--paginate` 同时支持 REST 列表接口和符合要求的 GraphQL 查询（GraphQL 查询须使用 `$endCursor`、`after: $endCursor` 并返回 `pageInfo.hasNextPage`/`endCursor`）。本技能第 5 步示例用 `$cursor` 手动翻页，属 GraphQL 手动分页；`--paginate` 只自动翻一个连接。
 - `app.quit()` / `os._exit` behaviors seen during crash diagnosis are unrelated to review handling; keep this skill scoped to review triage.
+- 自带等待脚本 `wait-coderabbit.ps1` / `wait-coderabbit-rate-limit.ps1` 的 `--jq` 过滤器不含字符串字面量：Windows PowerShell 5.1 向原生程序传参会剥掉内嵌双引号（PS 7.3+ 已修复），字符串一律经环境变量（`$ENV.CR_*`）传给 gojq，null 字段交由 `@tsv` 渲染为空。扩展过滤器时保持该约束，两个 PS 版本均可直接运行。

--- a/.agents/skills/ok-script-pr-review/wait-coderabbit-rate-limit.ps1
+++ b/.agents/skills/ok-script-pr-review/wait-coderabbit-rate-limit.ps1
@@ -29,6 +29,10 @@
 
 $ErrorActionPreference = "Stop"
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+# Windows PowerShell 5.1 向原生程序传参会剥掉内嵌双引号（PS 7.3+ 已修复），
+# --jq 过滤器一律不写字符串字面量，字符串经环境变量传给 gojq 的 $ENV.*。
+$env:CR_LOGIN = 'coderabbitai[bot]'
+$env:CR_BOT = 'Bot'
 
 function Invoke-GhChecked {
     param([string[]]$GhArgs)
@@ -41,13 +45,25 @@ function Invoke-GhChecked {
 
 function Get-LastCodeRabbitComment {
     # 返回最后一条 CodeRabbit 回复对象 { body, created_at }，无则 $null
-    # 服务端完成身份过滤、排序与 JSON 编码，避免 PowerShell 按系统 ANSI 解码整页 JSON。
-    $json = Invoke-GhChecked @(
-        "api", "--paginate", "--slurp", "repos/$Repo/issues/$PrNumber/comments", "--jq",
-        '[.[][] | select(.user.login == "coderabbitai[bot]" and .user.type == "Bot")] | sort_by(.created_at) | last | if . then {body, created_at} else empty end'
+    # 本机 gh（2.92+）不支持 --slurp 与 --jq 组合，改为分页处理：
+    # 每页取最后一条，输出 created_at + base64(body)；body 经 base64 规避
+    # TSV 无法承载换行以及 PowerShell 按 ANSI 解码 JSON 的两类问题。
+    $out = Invoke-GhChecked @(
+        "api", "--paginate", "repos/$Repo/issues/$PrNumber/comments", "--jq",
+        '[.[] | select(.user.login == $ENV.CR_LOGIN and .user.type == $ENV.CR_BOT)] | sort_by(.created_at) | last | if . then [.created_at, (.body | @base64)] | @tsv else empty end'
     )
-    if (-not $json) { return $null }
-    return $json | ConvertFrom-Json
+    if (-not $out) { return $null }
+    $latest = $null
+    foreach ($ln in ($out -split "`n")) {
+        $f = $ln.Trim() -split "`t"
+        if ($f.Count -lt 2 -or -not $f[0] -or -not $f[1]) { continue }
+        if ($null -eq $latest -or $f[0] -gt $latest.created_at) {
+            $latest = [pscustomobject]@{ created_at = $f[0]; body_b64 = $f[1] }
+        }
+    }
+    if (-not $latest) { return $null }
+    $body = [Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($latest.body_b64))
+    return [pscustomobject]@{ body = $body; created_at = $latest.created_at }
 }
 
 function Get-WaitMinutes {

--- a/.agents/skills/ok-script-pr-review/wait-coderabbit.ps1
+++ b/.agents/skills/ok-script-pr-review/wait-coderabbit.ps1
@@ -34,9 +34,16 @@
 # 编码注意：gh 输出是 UTF-8（评审 body 含中文），PowerShell 默认按系统 ANSI(GBK)
 # 解码会把 JSON 弄坏导致 ConvertFrom-Json 报错；因此除强制 UTF-8 外，
 # 所有结构化读取一律走服务端 --jq 输出 TSV，PowerShell 只按行拆字段。
+# 引号注意：Windows PowerShell 5.1 向原生程序传参会剥掉内嵌双引号（PS 7.3+ 已修复），
+# 因此 --jq 过滤器一律不写字符串字面量，字符串经环境变量传给 gojq 的 $ENV.*；
+# null 字段直接交给 @tsv（渲染为空字段），不再用 "" 兜底。
 
 $ErrorActionPreference = "Stop"
 [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+$env:CR_LOGIN = 'coderabbitai[bot]'
+$env:CR_BOT = 'Bot'
+$env:CR_CONTEXT = 'CodeRabbit'
+$env:CR_BLOCKING = 'CHANGES_REQUESTED'
 . (Join-Path $PSScriptRoot "wait-coderabbit-helpers.ps1")
 
 function Invoke-GhChecked {
@@ -58,7 +65,7 @@ function Get-LatestReview {
     param([string]$CommitSha = "")
     # 最新一条 CodeRabbit review；服务端过滤并输出 TSV（id|state|commit_id|submitted_at）
     $out = Invoke-GhChecked @("api", "--paginate", "repos/$Repo/pulls/$PrNumber/reviews", "--jq",
-        '.[] | select(.user.login == "coderabbitai[bot]" and .user.type == "Bot") | [.id, .state, (.commit_id // ""), .submitted_at] | @tsv')
+        '.[] | select(.user.login == $ENV.CR_LOGIN and .user.type == $ENV.CR_BOT) | [.id, .state, .commit_id, .submitted_at] | @tsv')
     if (-not $out) { return $null }
     $latest = $null
     foreach ($ln in ($out -split "`n")) {
@@ -75,7 +82,7 @@ function Get-LatestReview {
 function Get-CodeRabbitStatus {
     # 返回 head 上最新 CodeRabbit commit status 的 state/description/created_at；无则 $null
     $tsv = Invoke-GhChecked @("api", "repos/$Repo/commits/$headSha/status", "--jq",
-        '. as $combined | [.statuses[] | select(.context == "CodeRabbit")] | sort_by(.created_at) | reverse | .[0] | if . then [$combined.sha, .state, .description, .created_at] | @tsv else empty end')
+        '. as $combined | [.statuses[] | select(.context == $ENV.CR_CONTEXT)] | sort_by(.created_at) | reverse | .[0] | if . then [$combined.sha, .state, .description, .created_at] | @tsv else empty end')
     if (-not $tsv) { return $null }
     $first = ($tsv -split "`n")[0].Trim() -split "`t"
     if ($first.Count -lt 4) { return $null }
@@ -95,7 +102,7 @@ function Get-ForcePushEvent {
         "-f", "owner=$($repoParts[0])",
         "-f", "name=$($repoParts[1])",
         "-F", "number=$PrNumber",
-        "--jq", '.data.repository.pullRequest.timelineItems.nodes[] | [(.beforeCommit.oid // ""), (.afterCommit.oid // ""), .createdAt] | @tsv'
+        "--jq", '.data.repository.pullRequest.timelineItems.nodes[] | [(.beforeCommit.oid), (.afterCommit.oid), .createdAt] | @tsv'
     )
     $lines = if ($out) { @($out -split "`n") } else { @() }
     return Select-ForcePushEvent -SinceCommit $Commit -EventLines $lines
@@ -103,7 +110,7 @@ function Get-ForcePushEvent {
 
 function Get-ChangesRequestedReviews {
     $out = Invoke-GhChecked @("api", "--paginate", "repos/$Repo/pulls/$PrNumber/reviews", "--jq",
-        '.[] | select(.user.login == "coderabbitai[bot]" and .user.type == "Bot" and .state == "CHANGES_REQUESTED") | [.id, .state, (.commit_id // ""), .submitted_at] | @tsv')
+        '.[] | select(.user.login == $ENV.CR_LOGIN and .user.type == $ENV.CR_BOT and .state == $ENV.CR_BLOCKING) | [.id, .state, .commit_id, .submitted_at] | @tsv')
     if (-not $out) { return @() }
     $items = @()
     foreach ($ln in ($out -split "`n")) {
@@ -118,7 +125,7 @@ function Get-NewTopLevelComments {
     # 列出 id 大于基线的 CodeRabbit 顶层评审意见（id|path|line）
     param([long]$BaselineId)
     $out = Invoke-GhChecked @("api", "--paginate", "repos/$Repo/pulls/$PrNumber/comments", "--jq",
-        '.[] | select(.user.login == "coderabbitai[bot]" and .user.type == "Bot" and .in_reply_to_id == null) | [.id, .path, (.line // .original_line // 0)] | @tsv')
+        '.[] | select(.user.login == $ENV.CR_LOGIN and .user.type == $ENV.CR_BOT and .in_reply_to_id == null) | [.id, .path, (.line // .original_line // 0)] | @tsv')
     if (-not $out) { return @() }
     $items = @()
     foreach ($ln in ($out -split "`n")) {
@@ -131,7 +138,7 @@ function Get-NewTopLevelComments {
 
 function Get-MaxCommentId {
     $out = Invoke-GhChecked @("api", "--paginate", "repos/$Repo/pulls/$PrNumber/comments", "--jq",
-        '[.[] | select(.user.login == "coderabbitai[bot]" and .user.type == "Bot") | .id] | max // 0')
+        '[.[] | select(.user.login == $ENV.CR_LOGIN and .user.type == $ENV.CR_BOT) | .id] | max // 0')
     if (-not $out) { return 0 }
     return [long](([string]$out | Select-Object -Last 1).Trim())
 }


### PR DESCRIPTION
## 背景

`ok-script-pr-review` 的两个等待脚本在本机双双失效，排查发现两个独立根因，均已修复并实测：

1. **Windows PowerShell 5.1 原生传参会剥掉内嵌双引号**（PS 7.3+ 已修复该行为）：脚本里 `--jq` 过滤器含 `"coderabbitai[bot]"` 等字面量，5.1 下 jq 实际收到的是被剥掉引号的过滤器，报 `function not defined: bot/0`。
2. **`gh api --slurp` 与 `--jq` 互斥**：查证 cli/cli 源码与 [cli/cli#10459](https://github.com/cli/cli/issues/10459)，`--slurp` 自 v2.63.0（2024-10）引入起就禁止与 `--jq`/`--template` 组合，没有任何版本支持过；`wait-coderabbit-rate-limit.ps1` 原有的 `--paginate --slurp --jq` 写法在任何 gh 版本上都无法运行。

## 修复内容

### `wait-coderabbit.ps1`

- 全部 5 处 `--jq` 过滤器不再包含字符串字面量：`coderabbitai[bot]` / `Bot` / `CodeRabbit` / `CHANGES_REQUESTED` 改经环境变量 `$ENV.CR_*` 传给 gojq，PS 5.1 与 pwsh 7 行为一致。
- `// ""` 兜底改为直接交给 `@tsv`（null 渲染为空字段，实测字段对齐不变）。
- 文件头注释补充"引号注意"约束。

### `wait-coderabbit-rate-limit.ps1`

- 同样引入 `$ENV.CR_*`。
- `Get-LastCodeRabbitComment` 重构：去掉 `--slurp`，改为分页处理、每页取最后一条；body 用 `@base64` 传输（同时规避 TSV 无法承载换行与 PowerShell 按 ANSI 解码 JSON 两类问题），PS 侧 UTF-8 解码后返回结构不变。

### `SKILL.md`

- Gotchas 补一条约束：等待脚本的 `--jq` 过滤器不得含字符串字面量，字符串一律经 `$ENV.CR_*` 传入，防止后续扩展过滤器再次踩坑。

## 验证（PS 5.1 与 pwsh 7 双版本实测）

| 路径 | PS 5.1 | pwsh 7 |
|---|---|---|
| 普通等待（status + reviews 过滤器） | exit 0 | exit 0 |
| `-ListNewComments`（comments 过滤器） | exit 0，正确报"新增 0 条" | exit 0 |
| `-WaitMergeReady`（CHANGES_REQUESTED 过滤器） | exit 3，正确列出阻塞评审 | — |
| force-push 过滤器编译 | 通过 | 通过 |
| rate-limit 端到端（真实 bot 评论，`-NoTrigger`） | 正确解码并按预期 exit 1 | 同 |

两个 `.ps1` 均保留 UTF-8 BOM（5.1 下中文输出无乱码）。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * 修复 Windows PowerShell 5.1 及更高版本中的参数传递兼容性问题。
  * 改进 CodeRabbit 评论查询，支持分页处理并正确识别最新评论。
  * 改善空字段和特殊字符的处理，提升评审状态与评论信息读取的稳定性。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->