### PR TITLE
docs: 提交与 PR 纪律——master 锁定、仅收单职责 PR

### DIFF
--- a/.agents/skills/repository-workflow/SKILL.md
+++ b/.agents/skills/repository-workflow/SKILL.md
@@ -25,6 +25,8 @@ Use this skill for repository-wide rules that do not belong to a narrower domain
 3. Do not commit tokens, passwords, private keys, PEM files, credential exports, or secret-bearing config. GitHub App IDs may be repository variables; private keys belong only in Secrets.
 4. Follow recent repository commit language and use the established conventional prefix where applicable: `fix:`, `feat:`, `docs:`, `refactor:`, or `ci:`.
 5. A persisted task config-key rename must also load `ok-config-migration` and follow its strict sequence.
+6. Remote `master` is locked: never push commits to it directly. Every remote change lands only through a PR.
+7. One PR carries exactly one feature or one responsibility. Keep each PR's scope clear, and split mixed-responsibility changes into separate PRs before pushing.
 
 ## PowerShell Markdown safety
 


### PR DESCRIPTION
## 背景

仓库远程 `master` 已通过 ruleset 锁定，所有远程变更只能走 PR。为了让提交纪律与锁定状态一致，将以下准则正式写入 `repository-workflow` 技能的 Commit and PR checklist（新增第 6、7 条）：

> 6. Remote `master` is locked: never push commits to it directly. Every remote change lands only through a PR.
> 7. One PR carries exactly one feature or one responsibility. Keep each PR's scope clear, and split mixed-responsibility changes into separate PRs before pushing.

即：远程推送仅以开 PR 的方式进行，一个 PR 只承载单一功能、单一职责；混合职责的改动必须拆分后再推。

## 改动范围

仅 `.agents/skills/repository-workflow/SKILL.md`（Commit and PR checklist 追加两条），无代码改动。

`repository-workflow` 是 AGENTS.md 技能发现表中"提交/PR"场景对应的技能，凡执行提交或 PR 工作流时都会先加载该文件，本准则对所有提交路径生效。
