### PR TITLE
docs: 划分技能职责边界，新增 PR 远程基线规则

### DIFF
--- a/.agents/skills/deploy/SKILL.md
+++ b/.agents/skills/deploy/SKILL.md
@@ -7,6 +7,14 @@ description: Commit completed repository changes, create the next annotated vers
 
 Use this workflow to turn validated local changes into one commit and one annotated version tag, then push both to the publishing remote. If the user explicitly requests a local-only deployment, stop after creating the local tag.
 
+## Locked default branch
+
+Remote `master` is locked and only accepts changes through a PR (see the `repository-workflow` skill). Deploy must respect that lock:
+
+- If the worktree holds uncommitted code changes destined for `master`, stop before the commit step: land them through a PR first, then run this deploy flow on the merged result.
+- When the local branch already matches published `master` and no new commit is needed, skip the commit step and create the annotated tag on current `HEAD` instead.
+- Never push a deploy commit directly to `master`. The annotated-tag push itself is governed by the tag ruleset, not the branch lock.
+
 ## Variants
 
 - `deploy` or `deploy release`: create a stable tag, such as `v3.3.54`.
@@ -76,4 +84,5 @@ Use `next_tag.py` in this skill's `scripts/` directory (`.agents/skills/deploy/s
 - Never include merge commits when choosing the commit-message language.
 - Never infer a successful release from a local tag alone; report push success separately from CI publishing.
 - Do not push when the user explicitly requests a local-only commit or tag.
+- Never push a deploy commit directly to the locked default branch `master`; land code changes through a PR first and deploy the tag on the merged result.
 - Keep stable, beta, and alpha numbering independent except that the latest stable release closes older or equal prerelease base versions.

--- a/.agents/skills/deploy/SKILL.md
+++ b/.agents/skills/deploy/SKILL.md
@@ -12,8 +12,9 @@ Use this workflow to turn validated local changes into one commit and one annota
 Remote `master` is locked and only accepts changes through a PR (see the `repository-workflow` skill). Deploy must respect that lock:
 
 - If the worktree holds uncommitted code changes destined for `master`, stop before the commit step: land them through a PR first, then run this deploy flow on the merged result.
-- When the local branch already matches published `master` and no new commit is needed, skip the commit step and create the annotated tag on current `HEAD` instead.
-- Never push a deploy commit directly to `master`. The annotated-tag push itself is governed by the tag ruleset, not the branch lock.
+- When deploying on `master`, run `git fetch origin` first and require current `HEAD` to equal the published `origin/master` exactly, regardless of worktree cleanliness. A clean worktree with unpushed local commits must not be tagged or pushed; land those commits through a PR first.
+- When `HEAD` equals `origin/master` and no new commit is needed, skip the commit step and create the annotated tag on current `HEAD` instead.
+- On `master`, push only the annotated tag, never the branch ref. The annotated-tag push is governed by the tag ruleset, not the branch lock.
 
 ## Variants
 
@@ -68,9 +69,12 @@ Use `next_tag.py` in this skill's `scripts/` directory (`.agents/skills/deploy/s
    git show --no-patch --decorate HEAD
    ```
 
-7. Push the commit and annotated tag to the publishing remote, typically `origin`, unless the user explicitly requested local-only operation:
+7. Push to the publishing remote, typically `origin`, unless the user explicitly requested local-only operation. On the locked default branch `master`, push only the annotated tag; on any other branch, push the commit and the tag:
 
    ```powershell
+   # on master (tag-only; HEAD must already equal origin/master, see Locked default branch)
+   git push origin "<calculated-tag>"
+   # on any other branch
    git push origin HEAD "<calculated-tag>"
    ```
 

--- a/.agents/skills/ok-script-i18n/SKILL.md
+++ b/.agents/skills/ok-script-i18n/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: ok-script-i18n
-description: Add, sync, repair, and compile gettext translations for ok-script Python task classes and task metadata. Use when translating BaseTask and TriggerTask names, descriptions, default_config keys or values, config_description help text, config_type options, instructions, runtime messages, locale-specific ok.po catalogs, lang JSON placement, or debugging i18n collection-pool pollution.
+description: Add, sync, repair, and compile gettext translations for ok-script Python task classes and task metadata. Use when translating BaseTask and TriggerTask names, descriptions, default_config keys or values, config_description help text, config_type options, instructions, runtime messages, locale-specific ok.po catalogs, lang JSON vs gettext placement, or debugging i18n collection-pool pollution.
 ---
 
 # OK Script i18n
@@ -81,17 +81,13 @@ When adding or modifying an ok-script task:
 2. Then use `$ok-script-i18n` to sync gettext catalogs for those strings.
 3. Compile catalogs and include changed `.po` and `.mo` files in the final change summary.
 
-## Lang JSON Convention (assets/lang/)
+## Lang JSON Boundary (assets/lang/)
 
-`assets/lang/` language JSONs are a separate, parallel system to gettext. They hold task OCR match text and tracked localized business-data modules; they are not the same as `i18n/` catalogs.
+`assets/lang/` language JSONs are a separate, parallel system to gettext: they hold task OCR match text and tracked localized business-data modules, not `i18n/` catalogs. Everything about those files — schema, active OCR locales, key naming, file placement/archiving, `ocr_text_fix.json`, and verification — is owned by the `ok-script-ocr-lang` skill; read it before touching `assets/lang/` or `src/data/lang/`.
 
-- **New keys use semantic names** (e.g. `inst_title`, `inst_delivery_targets`), not the legacy `k_<md5前8位>` hash style.
-- Legacy `k_*` hash keys stay untouched — no migration needed; both styles coexist.
-- Each key must contain both active OCR locales (`zh_CN` and `zh_TW` today). Tracked full-locale business-data files also keep the six core locales (`zh_CN`/`zh_TW`/`en_US`/`ja_JP`/`ko_KR`/`es_ES`); existing modules may additionally carry other locales and those nodes must be preserved. Each locale node contains exactly one of `{"string": "..."}`, `{"pattern": "..."}`, or `{"terms": [...]}`.
-- Code reads via `self.lang.<模块名>.<语义化key>`, auto-selected by the current UI language (see `src/data/lang/`).
-- **Tracked full-locale JSON belongs in `assets/lang/`**: if each top-level business key directly contains complete locale nodes, keep the tracked file at `assets/lang/<module>.json`, even when it primarily serves a plugin or data query. Keep canonical/structured business data in `assets/data/`. Local generated files ignored by `.gitignore` retain their existing paths and ignored status.
-- **Task lang modules hold only OCR match text** (either `k_*` hash or semantic keys). Pure localized data modules such as `effect_names` and `yingtuo_stages` may serve plugins/data queries and do not need to be loaded by task OCR code. UI explanations (e.g. `instructions` rich text) do NOT go in lang JSON — use `self.tr("中文msgid")` through ok gettext: msgid into `i18n/*/LC_MESSAGES/ok.po` (msgid must match the code string verbatim, including full-width punctuation / `{placeholders}`), then `task_i18n_helper.py compile`.
-- Keep `scripts/i18n/gen_lang_stubs.py` `DATA_ONLY_MODULES` synchronized when adding another plugin/data-only module; runtime OCR modules may be accessed dynamically and must remain in the generated `self.lang` type hints even when no direct attribute reference is found.
+gettext-side rules that stay here:
+
+- UI explanations (e.g. `instructions` rich text) do NOT go in lang JSON — use `self.tr("中文msgid")` through ok gettext: msgid into `i18n/*/LC_MESSAGES/ok.po` (msgid must match the code string verbatim, including full-width punctuation / `{placeholders}`), then `task_i18n_helper.py compile`.
 - **Minimal principle**: emoji (`📍` `⚙️` `🖱️`), tree chars (`└─`/`├─`), HTML tags/colors that need no translation stay concatenated in code (e.g. `"📍 " + self.tr("滑索配置说明")`); only translatable plain text goes into i18n data (msgid/msgstr exclude emoji and decoration).
 - **Dynamic key-name translation**: config key names read dynamically in `instructions` (delivery points / target names / deposit-point names) must also pass through `self.tr(键名)` for display; msgid goes into ok.po (zh_TW in Traditional; other locales may keep Simplified for cross-referencing the config JSON key name). Look up config values with the raw key, display with the translated key (see `src/tasks/mixin/zip_line_mixin.py`).
 

--- a/.agents/skills/ok-script-ocr-lang/SKILL.md
+++ b/.agents/skills/ok-script-ocr-lang/SKILL.md
@@ -60,6 +60,15 @@ uv run --locked python scripts/i18n/gen_lang_stubs.py
 git diff -- src/data/lang/_lang_typed.py
 ```
 
+### Naming and file-placement conventions
+
+- **New keys use semantic names** (e.g. `inst_title`, `inst_delivery_targets`), not the legacy `k_<md5前8位>` hash style. Legacy `k_*` hash keys stay untouched — no migration needed; both styles coexist.
+- Tracked full-locale business-data files keep the six core locales (`zh_CN`/`zh_TW`/`en_US`/`ja_JP`/`ko_KR`/`es_ES`); existing modules may additionally carry other locales and those nodes must be preserved.
+- **Tracked full-locale JSON belongs in `assets/lang/`**: if each top-level business key directly contains complete locale nodes, keep the tracked file at `assets/lang/<module>.json`, even when it primarily serves a plugin or data query. Keep canonical/structured business data in `assets/data/`. Local generated files ignored by `.gitignore` retain their existing paths and ignored status.
+- **Task lang modules hold only OCR match text** (either `k_*` hash or semantic keys). Pure localized data modules such as `effect_names` and `yingtuo_stages` may serve plugins/data queries and do not need to be loaded by task OCR code.
+- Keep `scripts/i18n/gen_lang_stubs.py` `DATA_ONLY_MODULES` synchronized when adding another plugin/data-only module; runtime OCR modules may be accessed dynamically and must remain in the generated `self.lang` type hints even when no direct attribute reference is found.
+- gettext-side rules for UI text (`self.tr` usage, emoji minimal principle, dynamic key-name translation) live in the `ok-script-i18n` skill; UI explanations do not go in lang JSON.
+
 ## 4. OCR confusion patch (ocr_text_fix.json)
 
 - File: `assets/ocr_fix/ocr_text_fix.json`, schema is full-text `OCR 错误文本 -> 正确文本` pairs.

--- a/.agents/skills/ok-script-tasks/SKILL.md
+++ b/.agents/skills/ok-script-tasks/SKILL.md
@@ -39,7 +39,7 @@ Support English and Chinese in both code review and generated code.
 
 - Answer the user in the language they use. If unclear, use English with concise Chinese labels where useful.
 - Prefer stable English config keys because config keys become persisted JSON fields. Add Chinese help in `config_description` or through the project's translation system.
-- Include both English and Chinese OCR match text when the UI may appear in either language.
+- Include OCR match text for every active OCR locale of the target project instead of assuming a fixed language pair; in ok-end-field only `zh_CN` and `zh_TW` are active OCR locales (see `$ok-script-ocr-lang`).
 - Use `supported_languages` only to hide a task in unsupported locales. Common locale names are `en_US`, `zh_CN`, `zh_TW`, `ja_JP`, `ko_KR`, and `es_ES`.
 - Do not hard-code assumptions from the source project used to study `ok-script` unless the target project explicitly uses them.
 

--- a/.agents/skills/repository-workflow/SKILL.md
+++ b/.agents/skills/repository-workflow/SKILL.md
@@ -11,10 +11,7 @@ Use this skill for repository-wide rules that do not belong to a narrower domain
 
 ## Python environment and generated files
 
-- Dependency sources of truth are `pyproject.toml` and `uv.lock`.
-- Use `uv sync --locked` to materialize the repository `.venv`, and `uv run --locked python ...` for reproducible commands.
-- `requirements.txt` is generated for publishing workflows; do not edit it directly.
-- Run all tests with `scripts/testing/run_tests.ps1`, or a focused test with `uv run --locked python -m unittest <module> -v`.
+- Python environment, dependency, and test-entry rules are owned by the `use-local-venv` skill; read `.agents/skills/use-local-venv/SKILL.md` for command forms and the standard/focused test entry points.
 - Run skill/helper-script regressions with `uv run --locked python -m unittest tests.TestSkillScripts -v`.
 - Runtime diagnostics are in `logs/ok-script.log`; rotated files use `logs/ok-script.YYYY-MM-DD.log`.
 
@@ -27,6 +24,7 @@ Use this skill for repository-wide rules that do not belong to a narrower domain
 5. A persisted task config-key rename must also load `ok-config-migration` and follow its strict sequence.
 6. Remote `master` is locked: never push commits to it directly. Every remote change lands only through a PR.
 7. One PR carries exactly one feature or one responsibility. Keep each PR's scope clear, and split mixed-responsibility changes into separate PRs before pushing.
+8. Base every PR branch on the remote `master`: run `git fetch origin` first, branch from `origin/master`, and rebase onto it before pushing when behind. Never open a PR from a stale local `master`.
 
 ## PowerShell Markdown safety
 

--- a/.agents/skills/repository-workflow/SKILL.md
+++ b/.agents/skills/repository-workflow/SKILL.md
@@ -22,7 +22,7 @@ Use this skill for repository-wide rules that do not belong to a narrower domain
 3. Do not commit tokens, passwords, private keys, PEM files, credential exports, or secret-bearing config. GitHub App IDs may be repository variables; private keys belong only in Secrets.
 4. Follow recent repository commit language and use the established conventional prefix where applicable: `fix:`, `feat:`, `docs:`, `refactor:`, or `ci:`.
 5. A persisted task config-key rename must also load `ok-config-migration` and follow its strict sequence.
-6. Remote `master` is locked: never push commits to it directly. Every remote change lands only through a PR.
+6. Remote `master` is locked: never push code commits to it directly. Every code change to `master` must land through a PR; tags and other refs follow their own rulesets.
 7. One PR carries exactly one feature or one responsibility. Keep each PR's scope clear, and split mixed-responsibility changes into separate PRs before pushing.
 8. Base every PR branch on the remote `master`: run `git fetch origin` first, branch from `origin/master`, and rebase onto it before pushing when behind. Never open a PR from a stale local `master`.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # Skills
 
-本文件只负责技能发现。遇到下列场景时，先读取对应技能文件并按其中流程执行。
+本文件仅负责技能发现与路由，不重复定义技能中的具体流程、规则或实现细节。当任务命中下列任一场景时，先读取对应的 `SKILL.md`，再按技能文件中的流程执行。一个任务可以同时适用多个 Skill；应读取所有相关 Skill，并综合遵循其约束。
 
 | Skill | 适用场景 | 路径 |
 |---|---|---|
@@ -9,9 +9,10 @@
 | `use-local-venv` | 运行 Python、测试、lint、依赖检查或安装，统一使用 uv 与仓库 `.venv` | `.agents/skills/use-local-venv/SKILL.md` |
 | `ok-script-tasks` | 创建、修改、注册或审阅 `BaseTask` / `TriggerTask` 任务 | `.agents/skills/ok-script-tasks/SKILL.md` |
 | `ok-script-codegen` | 根据描述或截图生成任务 `run()` 自动化代码 | `.agents/skills/ok-script-codegen/SKILL.md` |
-| `ok-script-i18n` | gettext UI 文案、PO/MO、lang JSON 归档约定、收集池防污染与目录冲突合并 | `.agents/skills/ok-script-i18n/SKILL.md` |
-| `ok-script-ocr-lang` | OCR 匹配语言节点、active locale、`ocr_text_fix.json` 与语言引用排错 | `.agents/skills/ok-script-ocr-lang/SKILL.md` |
+| `ok-script-i18n` | gettext UI 文案、PO/MO、收集池防污染与目录冲突合并 | `.agents/skills/ok-script-i18n/SKILL.md` |
+| `ok-script-ocr-lang` | OCR 匹配语言节点、active locale、`assets/lang/` lang JSON 约定与归档、`ocr_text_fix.json` 与语言引用排错 | `.agents/skills/ok-script-ocr-lang/SKILL.md` |
 | `ok-config-migration` | 修改持久化配置键名并安全迁移用户数据 | `.agents/skills/ok-config-migration/SKILL.md` |
+| `wiki-skill-sync` | 从官方/第三方 wiki 同步干员技能数据、修复技能描述与效果数值 | `.agents/skills/wiki-skill-sync/SKILL.md` |
 | `ok-script-pr-review` | 触发、等待、核验、回复和解析 CodeRabbit PR 审阅 | `.agents/skills/ok-script-pr-review/SKILL.md` |
 | `github-workflows` | 编辑或排查 GitHub Actions YAML、权限、actionlint 与 SonarCloud 规则 | `.agents/skills/github-workflows/SKILL.md` |
 | `github-rulesets` | 分支/tag ruleset、bypass、GitHub App token 与受保护分支工作流 | `.agents/skills/github-rulesets/SKILL.md` |


### PR DESCRIPTION
## 概要

按「AGENTS.md 仅负责技能发现与路由、技能间不重复定义规则」的原则整理技能体系：

- **AGENTS.md**：改为三段式声明（仅路由 / 先读 SKILL.md / 多技能叠加时全部读取并综合遵循）；补上缺失的 `wiki-skill-sync` 行；i18n 行移除「lang JSON 归档约定」并移交 ocr-lang 行。
- **repository-workflow**：
  - Python 环境/依赖/测试入口规则改为指向 `use-local-venv`，消除两处近乎逐字的重复（单一所有者，防漂移）。
  - 新增规则 8：提 PR 必须以远程 `master`（`origin/master`）为基线——先 `git fetch origin` 再从 `origin/master` 分支，落后时先 rebase，禁止基于过期本地 master。（规则 6/7 的 master 锁定与单职责 PR 已由 #334 先行合入，本 PR 不重复收录。）
- **deploy**：新增 `Locked default branch` 一节与对应 Guardrail——去 master 的代码改动先走 PR；本地与远端 master 一致时跳过提交、直接在 HEAD 上打 tag；tag 推送受 tag ruleset 管辖，不受分支锁限制。
- **ok-script-i18n ↔ ok-script-ocr-lang**：`assets/lang/` 全部规则（schema、active locale、键名与归档、`ocr_text_fix.json`、验证）归 ocr-lang 单一所有；i18n 的 Lang JSON 节瘦身为边界声明，仅保留 gettext 侧规则（`self.tr` 用法、emoji 最小原则、动态键名翻译）。
- **ok-script-tasks**：OCR 匹配文本由「固定中英双语」改为「按目标项目 active OCR locale」，注明 ok-end-field 仅 `zh_CN` / `zh_TW`。

## 验证

- `uv run --locked python -m unittest tests.TestSkillScripts -v`：10/10 通过（rebase 到 f9f10595 后复跑）。
- 全局 grep 确认无对旧规则文本的残留引用。

## 冲突处理

- 分支已 rebase 到 `origin/master`（f9f10595）。#334 已先行合入 repository-workflow 规则 6/7，rebase 冲突按「保留 #334 措辞、仅追加规则 8」解决。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **文档**
  * 更新部署、分支管理与提交流程规范，明确锁定默认分支的操作要求。
  * 补充语言 JSON、OCR 文本、文件放置及多语言数据管理规范。
  * 更新任务双语输出指引，适配不同项目的活动 OCR 区域。
  * 完善技能发现、路由与适用场景说明。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->