### PR TITLE
chore: 为 JetBrains IDE 添加 ok-script Toolkit 插件推荐(.idea/externalDependencies.xml)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -75,7 +75,8 @@ python/
 
 ############################
 # 🧰 IDE
-.idea/
+.idea/*
+!.idea/externalDependencies.xml
 .vscode/*
 !.vscode/extensions.json
 !.vscode/settings.json

--- a/.idea/externalDependencies.xml
+++ b/.idea/externalDependencies.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="ExternalDependencies">
+    <plugin id="com.alicejump.okscripttoolkit" />
+  </component>
+</project>


### PR DESCRIPTION
## 背景

`.vscode/extensions.json` 已经推荐了 ok-script Toolkit 的 VS Code 版本（`AliceJump.ok-script-toolkit`）。本 PR 为 JetBrains IDE（PyCharm / IntelliJ IDEA 等）补上对等机制：`.idea/externalDependencies.xml`。

打开工程时，若未安装 `com.alicejump.okscripttoolkit` 插件，IDE 会主动弹出安装提示，效果等同 VS Code 的 extensions.json 推荐。

## 改动

- 新增 `.idea/externalDependencies.xml`：声明项目依赖插件 `com.alicejump.okscripttoolkit`（JetBrains Marketplace [ok-script Toolkit](https://plugins.jetbrains.com/plugin/34091-ok-script-toolkit)）
- `.gitignore`：`.idea/` 改为 `.idea/*` 并加 `!.idea/externalDependencies.xml` 例外，与现有 `.vscode/*` + `!.vscode/extensions.json` 的模式保持一致；其余 `.idea/` 文件（workspace.xml 等）仍保持忽略

## 关联

- JetBrains Marketplace: https://plugins.jetbrains.com/plugin/34091-ok-script-toolkit
- 现有 VS Code 推荐：`.vscode/extensions.json`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **其他**
  * 更新项目配置文件的忽略规则，保留外部依赖配置文件。
  * 新增 IntelliJ IDEA 外部依赖配置。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->