### PR TITLE
fix: resolve configs_dir in CI test

### DIFF
--- a/tests/TestConfigTransferPatch.py
+++ b/tests/TestConfigTransferPatch.py
@@ -141,7 +141,7 @@ class TestConfigTransferPatch(unittest.TestCase):
 
             backup_dir = apply_config_import(zip_path, configs_dir)
 
-            self.assertTrue(backup_dir.is_relative_to(configs_dir / "backup"))
+            self.assertTrue(backup_dir.is_relative_to(configs_dir.resolve() / "backup"))
             self.assertTrue(backup_dir.name.startswith("import_backup_"))
             # 旧配置完整备份（排除目录本身不重复备份）
             self.assertEqual((backup_dir / "_ok.json").read_text(encoding="utf-8"), "old_global")


### PR DESCRIPTION
## What

Fix CI test failure in test_apply_config_import_replaces_files_and_backs_up_old_config.

## Why

apply_config_import resolves configs_dir internally via .resolve(), so the returned backup_dir is based on the resolved path. The test compared this against an unresolved configs_dir / backup, which fails on GitHub Actions Windows runners where TEMP uses short paths (RUNNER~1) that resolve to full paths (runneradmin). Local Windows environments typically don't hit this because the temp path resolves to itself.

## Change

- tests/TestConfigTransferPatch.py:144: resolve configs_dir before comparison so the assertion works on both CI and local environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **测试**
  * 更新配置导入测试中的备份目录路径校验，使其与实际返回的解析后路径保持一致。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->