### PR TITLE
ci: add PR test workflow

### DIFF
--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -1,0 +1,91 @@
+name: PR Test
+
+on:
+  pull_request:
+    branches:
+      - master
+
+jobs:
+  test:
+    runs-on: windows-latest
+    permissions:
+      contents: read
+
+    env:
+      PYTHONIOENCODING: 'UTF-8'
+      PYTHONLEGACYWINDOWSSTDIO: 'UTF-8'
+
+    strategy:
+      matrix:
+        python-version: [ 3.12 ]
+
+    steps:
+      - name: Configure git
+        run: |
+          [Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+          git config --global core.autocrlf false
+          git config --global core.eol lf
+          git config --global user.email "ok-oldking@users.noreply.github.com"
+          git config --global user.name "ok-oldking"
+          echo "action_state=yellow" >> $env:GITHUB_ENV
+          echo "${{ env.action_state }}"
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+          lfs: true
+          fetch-depth: 0
+          fetch-tags: true
+
+      - name: Output immutable commit SHA
+        id: sha
+        shell: pwsh
+        run: |
+          "sha=$(git rev-parse HEAD)" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Resolve branch name
+        id: ref
+        shell: pwsh
+        run: |
+          $raw = "${{ github.head_ref }}"
+          $raw = $raw -replace "[\r\n]", ""
+          "branch=$raw" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+          $safe = $raw -replace '[/\\:<>*?"|]', '-'
+          "safe_branch=$safe" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v6
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install uv
+        run: |
+          pip install uv==0.10.9
+          uv venv .venv
+          uv pip install --python .venv packaging==26.3
+
+      - name: Verify requirements.txt reproducible
+        run: |
+          uv run --locked --no-sync python scripts/release/gen_release_requirements.py --check
+
+      - name: Install uv
+        run: |
+          pip install uv==0.10.9
+          uv venv .venv
+          uv pip install --python .venv --no-deps ok-script==2.0.2 pyappify==1.0.13
+
+      - name: inline_ok_requirements
+        env:
+          RELEASE_TAG: ${{ steps.ref.outputs.branch }}
+        run: |
+          uv run --locked --no-sync python -m ok.update.inline_ok_requirements --tag "$env:RELEASE_TAG"
+
+      - name: Install dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install polib
+
+      - name: Run tests
+        timeout-minutes: 5
+        run: |
+          python -u -m unittest discover -s tests -p "Test*.py" -v

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -46,8 +46,10 @@ jobs:
       - name: Resolve branch name
         id: ref
         shell: pwsh
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         run: |
-          $raw = "${{ github.head_ref }}"
+          $raw = $env:HEAD_REF
           $raw = $raw -replace "[\r\n]", ""
           "branch=$raw" | Out-File -FilePath $env:GITHUB_OUTPUT -Encoding utf8 -Append
           $safe = $raw -replace '[/\\:<>*?"|]', '-'


### PR DESCRIPTION
## What

Add a new GitHub Actions workflow that runs the same test suite as the Build workflow, but triggers on pull_request events (push/update to master).

## Why

Currently tests only run on tag pushes, repository_dispatch, and manual triggers. This means PRs don't get tested before merge. This workflow ensures PRs are validated with the same test configuration.

## Change

- Created .github/workflows/pr-test.yml with identical test configuration to build.yml's test job
- Triggers on pull_request events targeting master branch
- Uses the same Python version, uv setup, dependency installation, and test discovery
- Uses PR head SHA for checkout to ensure correct code is tested