### PR TITLE
refactor: 用最小插桩替代 execute() 复制以修复无帧任务跳变

### DIFF
--- a/src/patches/no_frame_task_patch.py
+++ b/src/patches/no_frame_task_patch.py
@@ -1,32 +1,97 @@
 """允许 TriggerTask / BaseTask 声明 needs_frame=False 以跳过整个截图管线。
 
-ok-script TaskExecutor.execute() 在每轮 trigger cycle 开始时无条件调用
-reset_scene() → self._frame = None，紧接着 next_frame() → method.get_frame()
-→ WGC do_get_frame()。对于纯 WS/键盘驱动、不需要画面识别的任务（如
-ItemNavigatorTask），这会产生不必要的 GPU 截图开销，甚至触发
-"latency too large return None frame" 警告。
+ok-script TaskExecutor 在每轮 trigger cycle 里无条件走截图流程：execute()
+调用 reset_scene() 清帧、next_frame() → method.get_frame() 截图。对于纯
+WS/键盘驱动、不需要画面识别的任务（如 ItemNavigatorTask），这会产生不必要
+的 GPU 截图开销，甚至触发 "latency too large return None frame" 警告。
 
-本补丁做三件事：
-1. 在 BaseTask.__init__ 中注入 needs_frame=True（默认行为不变）
-2. 在 TaskExecutor 的 next_frame() / reset_scene() 入口处检查当前任务的
-   needs_frame；若为 False 则短路返回，既不触发截图也不清空已有帧。
-3. 在 TaskExecutor.execute() 中仅将需要帧的任务的空帧视为截图失败；无帧
-   任务仍继续执行 run()。
+为什么必须处理 execute()
+----
+上游 execute() 中有一处判断：
 
-任务只需在自己的 __init__ 中设置 self.needs_frame = False 即可生效。
+    if cycled or self._frame is None:
+        if self.next_frame(time_out=4) is None and is_trigger_task:
+            # 把"取不到帧"一律当作截图失败，跳过剩余 trigger 任务
+            continue
+
+无帧任务的 next_frame() 永远不会截图，_frame 始终为 None，因此这句必然
+命中，任务会被无限跳过——这正是 #353 需要修掉的点。所以仅包装
+next_frame()/reset_scene() 不够，execute() 里的判断也必须被中和。
+
+为什么不是复制 execute()
+----
+早期实现把整个 execute()（约 100 行，含异常处理与退出逻辑）复制了一份。
+核对上游源码后可以确认：复制体相对上游**唯一的真实语义改动**就是给这句
+加上 `and _task_wants_frame(self)`，其余全是逐行照抄。这种做法的代价是
+与上游强耦合——ok-script 升级 execute()（改异常分支、加超时、调退出顺序）
+时补丁不会报错，只会静默运行一份过期的执行循环，漂移极难发现。
+
+本补丁改用最小插桩，不复制任何上游实现体：
+
+1. BaseTask.__init__ 末尾注入 needs_frame=True（默认行为不变）
+2. 包装 next_frame()：无帧任务不截图，返回一个"已就绪"的哨兵帧
+3. 包装 reset_scene()：无帧任务跳过清帧，但仍执行 check_enabled()
+4. execute() 保持上游原样，不做替换
+
+关键在第 2 步的返回值：无帧任务返回哨兵帧而非 None，于是上游那句
+`next_frame(...) is None and is_trigger_task` 自然不成立，任务不会被跳过；
+而 execute() 后续走的是 `if is_trigger_task: task.run()`，直接执行任务，
+不需要帧。这样"是否截图"由本补丁决定，而执行循环、异常处理、退出逻辑
+全部由上游代码决定，升级不会产生静默语义漂移。
+
+哨兵帧的约定
+----
+哨兵帧需要满足上游对返回值的 `is None` 判断，因此必须**非 None**；但
+**不得写入 self._frame**，否则 execute() 异常路径的
+
+    if self._frame is not None:
+        communicate.screenshot.emit(self.frame, name, True, None)
+
+会把哨兵送进截图管线（PIL/cv2）导致 worker 线程报错。所以 self._frame
+保持 None，`frame` property 也不会把哨兵交给需要真实图像的调用方。
 """
 
 from __future__ import annotations
 
-from functools import wraps
+import logging
 
 _PATCH_INSTALLED = False
 
+logger = logging.getLogger(__name__)
+
+
+class _FrameReadySentinel:
+    """无帧任务的占位"帧"：非 None，用于让上游 `is None` 判断失效。
+
+    无帧任务的 run() 契约是不读取画面；若任务真的访问了帧内容，会立刻在
+    本对象上抛 AttributeError，而不是悄悄拿到 None 后继续运行。
+    """
+
+    __slots__ = ()
+
+    def __repr__(self) -> str:  # pragma: no cover - 仅调试可读性
+        return "<needs_frame=False: 该任务不截图>"
+
+    def __bool__(self) -> bool:
+        return True
+
+    def __getattr__(self, item):
+        raise AttributeError(
+            f"任务声明了 needs_frame=False，不应访问帧属性 {item!r}；"
+            "请检查该任务是否真的不需要画面"
+        )
+
+
+_FRAME_READY = _FrameReadySentinel()
+
+
+def _current_task(executor):
+    return getattr(executor, "current_task", None)
+
 
 def _task_wants_frame(executor) -> bool:
-    """当前任务是否需要帧截图（保守默认 True）。"""
-    task = getattr(executor, "current_task", None)
-    return getattr(task, "needs_frame", True)
+    """当前任务是否需要帧截图（保守默认 True：拿不到任务时按需要帧处理）。"""
+    return getattr(_current_task(executor), "needs_frame", True)
 
 
 def install_no_frame_task_patch():
@@ -34,149 +99,80 @@ def install_no_frame_task_patch():
     if _PATCH_INSTALLED:
         return
 
-    from ok.task.task import BaseTask
     from ok.task.TaskExecutor import TaskExecutor
+    from ok.task.task import BaseTask
+
+    _require_upstream_contract(TaskExecutor, BaseTask)
 
     # --- 1. 注入 needs_frame 属性 -------------------------------------------
     _original_base_init = BaseTask.__init__
 
-    @wraps(_original_base_init)
     def _patched_base_init(self, *args, **kwargs):
         _original_base_init(self, *args, **kwargs)
         # 仅在 __init__ 末尾追加，不覆盖子类可能已设置的值
         if not hasattr(self, "needs_frame"):
             self.needs_frame = True
 
+    _patched_base_init.__wrapped__ = _original_base_init
     BaseTask.__init__ = _patched_base_init
 
-    # --- 2. 让 reset_scene() 在不需要帧时跳过清帧 --------------------------
-    _original_reset_scene = TaskExecutor.reset_scene
-
-    @wraps(_original_reset_scene)
-    def _patched_reset_scene(self, check_enabled=True):
-        if not _task_wants_frame(self):
-            # 任务声明不需要帧 → 保留已有帧，不触发 reset_scene 中的清帧逻辑
-            # 仍需执行 check_enabled 以保证任务启停检测正常
-            if check_enabled:
-                self.check_enabled()
-            return
-        return _original_reset_scene(self, check_enabled)
-
-    TaskExecutor.reset_scene = _patched_reset_scene
-
-    # --- 3. 让 next_frame() 在不需要帧时短路 --------------------------------
+    # --- 2. next_frame()：无帧任务不截图，返回哨兵帧 --------------------------
     _original_next_frame = TaskExecutor.next_frame
 
-    @wraps(_original_next_frame)
     def _patched_next_frame(self, time_out=6):
         if not _task_wants_frame(self):
-            # 任务声明不需要帧 → 直接返回已缓存帧（可能为 None），不触发截图
-            return self._frame
+            # 不调用上游 next_frame()，因此不触发 get_frame()/截图。
+            # 返回哨兵帧：让上游 execute() 的 `... is None and is_trigger_task`
+            # 判断失效，任务得以继续执行 run()。
+            #
+            # 注意：**不写入 self._frame**。self._frame 仍保持 None，这样：
+            #   - `frame` property 不会把哨兵交给需要真实图像的调用方；
+            #   - execute() 异常路径的 `if self._frame is not None:
+            #     communicate.screenshot.emit(self.frame, ...)` 保持不触发，
+            #     避免把哨兵帧送进截图管线（PIL/cv2）导致 worker 线程报错。
+            return _FRAME_READY
         return _original_next_frame(self, time_out)
 
+    _patched_next_frame.__wrapped__ = _original_next_frame
     TaskExecutor.next_frame = _patched_next_frame
 
-    # --- 4. 让 execute() 区分“截图失败”和“任务无需截图” ------------------
-    _original_execute = TaskExecutor.execute
+    # --- 3. reset_scene()：无帧任务跳过清帧，但保留 check_enabled ------------
+    _original_reset_scene = TaskExecutor.reset_scene
 
-    @wraps(_original_execute)
-    def _patched_execute(self):
-        logger = _original_execute.__globals__["logger"]
-        communicate = _original_execute.__globals__["communicate"]
-        alert_info = _original_execute.__globals__["alert_info"]
-        prevent_sleeping = _original_execute.__globals__["prevent_sleeping"]
-        time = _original_execute.__globals__["time"]
-        TaskDisabledException = _original_execute.__globals__["TaskDisabledException"]
-        FinishedException = _original_execute.__globals__["FinishedException"]
-        CaptureException = _original_execute.__globals__["CaptureException"]
-        HotkeyConfigException = _original_execute.__globals__["HotkeyConfigException"]
+    def _patched_reset_scene(self, check_enabled=True):
+        if not _task_wants_frame(self):
+            if check_enabled:
+                self.check_enabled()
+            return None
+        return _original_reset_scene(self, check_enabled)
 
-        logger.info("start execute")
-        while not self.exit_event.is_set():
-            if self.paused:
-                logger.info("executor is paused sleep")
-                self.sleep(1)
-            wake_version = self._get_wake_version()
-            task, cycled, is_trigger_task = self.next_task()
-            if not task:
-                self._wait_for_activity(self.next_trigger_delay(), wake_version)
-                continue
-            if cycled or time.time() - self._last_frame_time > 0.2:
-                self.reset_scene()
-            try:
-                task.start_time = time.time()
-                task.running = True
-                self.current_task = task
-                if not is_trigger_task:
-                    communicate.task.emit(task)
-                if cycled or self._frame is None:
-                    if self.next_frame(time_out=4) is None and is_trigger_task and _task_wants_frame(self):
-                        logger.info("no frame available, skip remaining trigger tasks")
-                        self.trigger_task_index = len(self.trigger_tasks) - 1
-                        self.current_task = None
-                        task.running = False
-                        continue
-                if is_trigger_task:
-                    if task.run():
-                        self.trigger_task_index = -1
-                        self.reset_scene()
-                        continue
-                else:
-                    prevent_sleeping(True)
-                    logger.debug(f"start running onetime_task {task.name}")
-                    task.run()
-                    logger.debug(f"end running onetime_task {task.name}")
-                    prevent_sleeping(False)
-                    task.disable()
-                    communicate.task_done.emit(task)
-                    if task.exit_after_task or task.config.get("Exit After Task"):
-                        logger.info("Successfully Executed Task, Exiting Game and App!")
-                        alert_info("Successfully Executed Task, Exiting Game and App!")
-                        time.sleep(5)
-                        self.device_manager.stop_hwnd()
-                        time.sleep(5)
-                        communicate.quit.emit()
-                task.running = False
-                self.current_task = None
-                if not is_trigger_task:
-                    communicate.task.emit(task)
-            except TaskDisabledException:
-                logger.info(f"TaskDisabledException, continue {task}")
-                task.running = False
-                self.current_task = None
-                if not is_trigger_task:
-                    communicate.task.emit(task)
-                communicate.notification.emit("Stopped", task.name, False, False, None, None, None)
-                continue
-            except FinishedException:
-                logger.info("FinishedException, breaking")
-                task.running = False
-                self.current_task = None
-                if not is_trigger_task:
-                    communicate.task.emit(task)
-                break
-            except Exception as e:
-                if isinstance(e, CaptureException):
-                    communicate.capture_error.emit()
-                name = task.name
-                task.running = False
-                task.disable()
+    _patched_reset_scene.__wrapped__ = _original_reset_scene
+    TaskExecutor.reset_scene = _patched_reset_scene
 
-                params = None
-                if isinstance(e, HotkeyConfigException):
-                    error = "{key} is invalid, please check the hotkey config!"
-                    params = {"key": e.key}
-                else:
-                    error = str(e)
-                communicate.notification.emit(error, name, True, True, None, params, None)
-                task.info_set(task._app.tr("Error"), error)
-                logger.error(f"{name} exception stopped", e)
-                if self._frame is not None:
-                    communicate.screenshot.emit(self.frame, name, True, None)
-                self.current_task = None
-                communicate.task.emit(None)
-        self.destroy()
-
-    TaskExecutor.execute = _patched_execute
+    # --- 4. execute()：不替换，保持上游实现 ----------------------------------
+    # 上游 execute() 会经过上面两个包装，行为已满足需求。此处显式记录
+    # 该决定，防止后人再次复制整个 execute()。
 
     _PATCH_INSTALLED = True
+    logger.info("no_frame_task_patch installed (minimal instrumentation)")
+
+
+def _require_upstream_contract(TaskExecutor, BaseTask) -> None:
+    """校验依赖的上游接口仍在，缺失时显式失败而不是静默降级。
+
+    ok-script 升级若改动这些成员，应当启动即报错，而不是运行到一半才暴露。
+    """
+    required_executor_attrs = (
+        "next_frame",
+        "reset_scene",
+        "execute",
+        "check_enabled",
+    )
+    missing = [name for name in required_executor_attrs if not hasattr(TaskExecutor, name)]
+    if missing:
+        raise RuntimeError(
+            "no_frame_task_patch 依赖的 TaskExecutor 成员缺失: "
+            f"{missing}；请更新 src/patches/no_frame_task_patch.py 以适配新版 ok-script"
+        )
+    if not callable(getattr(BaseTask, "__init__", None)):
+        raise RuntimeError("no_frame_task_patch 依赖 BaseTask.__init__，请检查 ok-script 版本")

--- a/tests/TestNoFrameTaskPatch.py
+++ b/tests/TestNoFrameTaskPatch.py
@@ -1,0 +1,249 @@
+"""no_frame_task_patch 的单元测试。
+
+背景
+----
+`#353` 需要让纯 WS/键盘驱动的任务（如 ItemNavigatorTask）声明
+`needs_frame=False` 后跳过整条截图管线。上游 TaskExecutor.execute() 里有：
+
+    if cycled or self._frame is None:
+        if self.next_frame(time_out=4) is None and is_trigger_task:
+            # 取不到帧 -> 跳过剩余 trigger 任务
+            continue
+
+无帧任务永远不截图，`self._frame` 恒为 None，因此这句会命中并无限跳过任务。
+
+核心回归点
+----------
+早期实现把整个 execute()（约 100 行）复制了一份，只为加一句
+`and _task_wants_frame(self)`，导致与上游强耦合：ok-script 升级 execute()
+时补丁静默失效。本测试锁定"最小插桩"方案的两条不变量：
+
+1. `TaskExecutor.execute` 必须保持上游原对象——**不得**被复制替换；
+2. 无帧任务经上游 execute() 的"无帧跳过"分支时，必须仍能执行 run()。
+
+隔离策略
+--------
+用替身 TaskExecutor / BaseTask 注入 `ok.task.*` 模块，避免依赖真实 ok 库；
+测试类结束后恢复原模块对象与全局安装标记。
+"""
+
+import sys
+import types
+import unittest
+
+from src.patches import no_frame_task_patch as nf
+
+
+class _FakeExecutor:
+    """忠实复刻上游 TaskExecutor 的相关方法。"""
+
+    def __init__(self):
+        self._frame = None
+        self.current_task = None
+        self.capture_calls = 0
+        self.skipped = False
+        self.ran_tasks = []
+        self.trigger_tasks = [object()]
+        self.trigger_task_index = -1
+
+    def execute(self):  # noqa: D102 - 契约占位
+        return None
+
+    def check_enabled(self, check_pause=True):
+        pass
+
+    def get_frame(self):
+        self.capture_calls += 1
+        return "REAL_FRAME"
+
+    def next_frame(self, time_out=6):
+        self.reset_scene()
+        self._frame = self.get_frame()
+        return self._frame
+
+    @property
+    def frame(self):
+        """模拟上游 frame property（供检查哨兵是否会流入截图管线）。"""
+        return self._frame
+
+    def reset_scene(self, check_enabled=True):
+        self._frame = None
+
+    def execute_one_trigger_cycle(self, task):
+        """复刻 execute() 内 trigger 任务的处理路径（含无帧跳过分支）。"""
+        self.current_task = task
+        cycled = True
+        is_trigger_task = True
+        if cycled or self._frame is None:
+            if self.next_frame(time_out=4) is None and is_trigger_task:
+                self.skipped = True
+                self.current_task = None
+                return "SKIPPED"
+        if is_trigger_task:
+            task.run()
+            self.ran_tasks.append(task.name)
+            return "RAN"
+        return "?"
+
+
+class _FakeTask:
+    def __init__(self, needs_frame=True):
+        self.name = "trigger"
+        self.needs_frame = needs_frame
+        self.run_calls = 0
+
+    def run(self):
+        self.run_calls += 1
+        return False
+
+
+class _BaseTask:
+    def __init__(self):
+        self.name = "base"
+
+
+# 在导入期捕获"上游 execute"的原始函数对象。直接通过类属性访问会触发
+# 描述符绑定变成 bound method，identity 比较必然失败，故从 __dict__ 取。
+_ORIGINAL_EXECUTE_FUNC = _FakeExecutor.__dict__["execute"]
+
+
+def _current_execute_func():
+    return _FakeExecutor.__dict__["execute"]
+
+
+class TestNoFrameTaskPatch(unittest.TestCase):
+    _saved_modules = None
+    _original_flag = None
+    _original_execute = None
+    _cleanup_completed = False
+
+    @classmethod
+    def setUpClass(cls):
+        cls._saved_modules = {
+            name: sys.modules.get(name)
+            for name in ("ok", "ok.task", "ok.task.TaskExecutor", "ok.task.task")
+        }
+
+        fake_executor_mod = types.ModuleType("ok.task.TaskExecutor")
+        fake_executor_mod.TaskExecutor = _FakeExecutor
+        fake_task_mod = types.ModuleType("ok.task.task")
+        fake_task_mod.BaseTask = _BaseTask
+
+        fake_ok = types.ModuleType("ok")
+        fake_task_pkg = types.ModuleType("ok.task")
+        fake_task_pkg.TaskExecutor = fake_executor_mod
+        fake_task_pkg.task = fake_task_mod
+
+        sys.modules["ok"] = fake_ok
+        sys.modules["ok.task"] = fake_task_pkg
+        sys.modules["ok.task.TaskExecutor"] = fake_executor_mod
+        sys.modules["ok.task.task"] = fake_task_mod
+
+        cls._original_flag = nf._PATCH_INSTALLED
+        cls._original_execute = _ORIGINAL_EXECUTE_FUNC
+        cls.addClassCleanup(cls._restore_state)
+
+        nf._PATCH_INSTALLED = False
+        nf.install_no_frame_task_patch()
+
+    @classmethod
+    def _restore_state(cls):
+        for name, module in cls._saved_modules.items():
+            if module is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = module
+        nf._PATCH_INSTALLED = cls._original_flag
+        cls._cleanup_completed = True
+
+    def test_execute_not_replaced(self):
+        """核心不变量：execute() 必须保持上游原实现，不得复制替换。"""
+        self.assertIs(_current_execute_func(), _ORIGINAL_EXECUTE_FUNC)
+
+    def test_next_frame_and_reset_scene_wrapped(self):
+        self.assertTrue(hasattr(_FakeExecutor.next_frame, "__wrapped__"))
+        self.assertTrue(hasattr(_FakeExecutor.reset_scene, "__wrapped__"))
+
+    def test_no_frame_task_does_not_capture(self):
+        ex = _FakeExecutor()
+        ex.current_task = _FakeTask(needs_frame=False)
+        result = ex.next_frame(time_out=4)
+        self.assertEqual(ex.capture_calls, 0)
+        self.assertIsNotNone(result, "哨兵帧必须非 None 才能让上游 is None 判断失效")
+
+    def test_sentinel_not_stored_in_frame(self):
+        """哨兵帧不得写入 self._frame，否则异常路径会把它送进截图管线。"""
+        ex = _FakeExecutor()
+        ex.current_task = _FakeTask(needs_frame=False)
+        ex.next_frame(time_out=4)
+        self.assertIsNone(
+            ex._frame,
+            "self._frame 必须保持 None，避免 execute() 异常路径 "
+            "communicate.screenshot.emit(self.frame, ...) 处理哨兵对象",
+        )
+        self.assertIsNone(ex.frame)
+
+    def test_no_frame_trigger_task_not_skipped(self):
+        """核心回归：无帧 trigger 任务不被 'no frame available' 分支跳过。"""
+        ex = _FakeExecutor()
+        task = _FakeTask(needs_frame=False)
+        outcome = ex.execute_one_trigger_cycle(task)
+        self.assertEqual(outcome, "RAN")
+        self.assertFalse(ex.skipped)
+        self.assertEqual(task.run_calls, 1)
+        self.assertEqual(ex.capture_calls, 0, "无帧任务全流程不应截图")
+
+    def test_frame_task_behavior_unchanged(self):
+        ex = _FakeExecutor()
+        task = _FakeTask(needs_frame=True)
+        outcome = ex.execute_one_trigger_cycle(task)
+        self.assertEqual(outcome, "RAN")
+        self.assertEqual(ex.capture_calls, 1, "有帧任务应正常截图")
+        self.assertEqual(task.run_calls, 1)
+
+    def test_reset_scene_keeps_frame_for_no_frame_task(self):
+        ex = _FakeExecutor()
+        ex.current_task = _FakeTask(needs_frame=False)
+        ex._frame = "KEEP"
+        ex.reset_scene()
+        self.assertEqual(ex._frame, "KEEP")
+
+    def test_reset_scene_clears_frame_for_frame_task(self):
+        ex = _FakeExecutor()
+        ex.current_task = _FakeTask(needs_frame=True)
+        ex._frame = "DROP"
+        ex.reset_scene()
+        self.assertIsNone(ex._frame)
+
+    def test_base_task_defaults_needs_frame_true(self):
+        self.assertTrue(_BaseTask().needs_frame)
+
+    def test_install_idempotent(self):
+        before_next = _FakeExecutor.next_frame
+        nf.install_no_frame_task_patch()
+        self.assertIs(_FakeExecutor.next_frame, before_next)
+        self.assertTrue(nf._PATCH_INSTALLED)
+
+    def test_missing_upstream_contract_raises(self):
+        class _Broken:
+            pass
+
+        with self.assertRaises(RuntimeError) as ctx:
+            nf._require_upstream_contract(_Broken, _BaseTask)
+        self.assertIn("TaskExecutor 成员缺失", str(ctx.exception))
+
+    def test_sentinel_frame_access_raises_clear_error(self):
+        with self.assertRaises(AttributeError) as ctx:
+            nf._FRAME_READY.shape
+        self.assertIn("needs_frame=False", str(ctx.exception))
+
+
+class TestZNoFrameTaskPatchStateRestored(unittest.TestCase):
+    def test_global_state_restored_after_patch_tests(self):
+        self.assertTrue(TestNoFrameTaskPatch._cleanup_completed)
+        self.assertEqual(nf._PATCH_INSTALLED, TestNoFrameTaskPatch._original_flag)
+        self.assertIs(_current_execute_func(), _ORIGINAL_EXECUTE_FUNC)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
#353 需要让纯 WS/键盘驱动的任务声明 needs_frame=False 后跳过整条截图 管线。上游 execute() 中的

    if self.next_frame(time_out=4) is None and is_trigger_task:
        continue

会把"无帧任务取不到帧"误判为截图失败，导致任务被无限跳过。

早期实现复制了一份完整 execute()（约 100 行），只为给该判断加一个 `and _task_wants_frame(self)`。核对上游源码后确认这是相对上游唯一的真实 语义改动，其余逐行照抄；一旦 ok-script 升级 execute()，补丁会静默运行 过期的执行循环，漂移极难发现。

改为最小插桩，不复制任何上游实现体：

- 包装 next_frame()：无帧任务不截图，返回非 None 的哨兵帧，使上游 `is None` 判断自然失效；哨兵不写入 self._frame，避免 execute() 异常 路径把它送进截图管线
- 包装 reset_scene()：无帧任务跳过清帧，但保留 check_enabled()
- execute() 保持上游原样，不替换
- 新增 _require_upstream_contract()：依赖的上游成员缺失时启动即报错， 而非运行中途静默降级

新增 tests/TestNoFrameTaskPatch.py，锁定两条不变量：execute() 必须保持 上游原对象；无帧 trigger 任务必须仍能执行 run()。13 项测试全部通过。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug 修复**
  * 修复无画面任务可能被错误跳过的问题，确保其正常执行。
  * 无画面任务不再清除现有画面或触发截图。
  * 保持有画面任务的原有行为不变。

* **测试**
  * 新增针对无画面任务处理、画面状态保留、重复安装及异常场景的测试覆盖。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->