### PR TITLE
fix:跳对话早退出

### DIFF
--- a/src/core/base_mixin/game_flow_mixin.py
+++ b/src/core/base_mixin/game_flow_mixin.py
@@ -108,10 +108,19 @@ class GameFlowMixin:
             if self.active_time() - start_time > time_out:
                 self.log_info("skip_dialog 超时退出")
                 return False
-            if self.find_one(fL.skip_dialog_esc, horizontal_variance=0.05):
-                self.press_esc()
+            if result := self.wait_feature(
+                [fL.skip_dialog_esc, fL.skip_dialog_confirm],
+                horizontal_variance=0.05,
+                raise_if_not_found=False,
+                time_out=1,
+            ):
+                if result.name == "skip_dialog_esc":
+                    self.press_esc()
                 self.click_confirm()
+            else:
+                return True
             self.sleep(0.5)
+        return False
 
     def find_confirm(self):
         """
@@ -604,7 +613,7 @@ class GameFlowMixin:
             features = (
                 default_features + addtional_feature
                 if isinstance(addtional_feature, list)
-                else default_features + [addtional_feature]
+                else [*default_features, addtional_feature]
             )
         else:
             features = default_features


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - 优化跳过对话框的处理：现在会在 1 秒内同时识别“跳过”和“确认”操作。
  - 检测到跳过选项时会先执行跳过，再统一确认；未检测到相关选项时将直接结束等待，减少不必要的停顿。
  - 优化地图确认流程，保持原有行为不变。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->