### PR TITLE
fix: 转交运送委托在任务面板折叠线以下时滚动重试查找

### DIFF
--- a/src/tasks/daily/misc/daily_logistics_mixin.py
+++ b/src/tasks/daily/misc/daily_logistics_mixin.py
@@ -93,6 +93,32 @@ class DailyLogisticsMixin:
         self.log_info("转交委托奖励领取完成")
         return True
 
+    def _click_transfer_commission_in_task_panel(self, max_scroll=7):
+        """在任务面板中向下滚动查找并点击「转交运送委托」。
+
+        「转交运送委托」位于任务面板列表的折叠线以下时，
+        只做一次静态识别会直接漏判，并被误当成「本次活动不可转交」而放弃。
+        因此在面板内向下滚动重试，滚动次数与
+        daily_credit_mixin.collect_credit 的滚动重试保持一致。
+
+        Args:
+            max_scroll: 最大向下滚动次数。
+
+        Returns:
+            bool: 找到并点击返回 True；滚动次数耗尽仍未找到返回 False。
+        """
+        if self.wait_click_ocr(match=self.lang.daily_routine_mixin.k_1dd73947, box=self.box.bottom_left, time_out=5):
+            return True
+
+        for _ in range(max_scroll):
+            self.scroll_relative(0.5, 0.5, -4)
+            self.wait_ui_stable(refresh_interval=1)
+            if self.wait_click_ocr(
+                match=self.lang.daily_routine_mixin.k_1dd73947, box=self.box.bottom_left, time_out=5
+            ):
+                return True
+        return False
+
     def delivery_send_others(self):
         self.info_set("current_task", "delivery_send_others")
 
@@ -192,9 +218,7 @@ class DailyLogisticsMixin:
                 self.ensure_main()
                 self.press_key("j", after_sleep=1)
 
-                if not self.wait_click_ocr(
-                    match=self.lang.daily_routine_mixin.k_1dd73947, box=self.box.bottom_left, time_out=5
-                ):
+                if not self._click_transfer_commission_in_task_panel():
                     self.log_info("未找到 '转交运送委托' 按钮，跳过本次活动")
                     self.ensure_main()
                     break

--- a/tests/TestDeliveryCommissionPanelScroll.py
+++ b/tests/TestDeliveryCommissionPanelScroll.py
@@ -1,0 +1,46 @@
+import unittest
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from src.tasks.daily.misc.daily_logistics_mixin import DailyLogisticsMixin
+
+
+class TestTransferCommissionPanelScroll(unittest.TestCase):
+    """_click_transfer_commission_in_task_panel 在任务面板内滚动查找（转交运送委托）。"""
+
+    def make_feature(self, click_results):
+        feature = object.__new__(DailyLogisticsMixin)
+        feature.log_info = Mock()
+        feature.wait_click_ocr = Mock(side_effect=click_results)
+        feature.scroll_relative = Mock()
+        feature.wait_ui_stable = Mock(return_value=True)
+        feature.box = SimpleNamespace(bottom_left=object())
+        feature.lang = SimpleNamespace(
+            daily_routine_mixin=SimpleNamespace(
+                k_1dd73947="转交运送委托",
+            )
+        )
+        return feature
+
+    def test_found_without_scrolling(self):
+        feature = self.make_feature([True])
+
+        self.assertTrue(feature._click_transfer_commission_in_task_panel())
+        feature.scroll_relative.assert_not_called()
+
+    def test_found_after_scrolling_down(self):
+        # 首屏折叠线以下，向下滚动两次后才识别到
+        feature = self.make_feature([False, False, True])
+
+        self.assertTrue(feature._click_transfer_commission_in_task_panel())
+        self.assertEqual(feature.scroll_relative.call_count, 2)
+
+    def test_not_found_exhausts_scroll_budget(self):
+        feature = self.make_feature([False] * 8)
+
+        self.assertFalse(feature._click_transfer_commission_in_task_panel())
+        self.assertEqual(feature.scroll_relative.call_count, 7)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 问题

`daily_routine.delivery_send_others` 在部分地区必定失败：

```
23:30:24 未找到 '转交运送委托' 按钮，跳过本次活动
23:31:03 任务失败标记 | ⭐转交运送委托: 未完成任何转交运送委托操作
```

`press_key("j")` 打开任务面板后，代码只做一次静态 OCR：

```python
if not self.wait_click_ocr(
    match=self.lang.daily_routine_mixin.k_1dd73947, box=self.box.bottom_left, time_out=5
):
    self.log_info("未找到 '转交运送委托' 按钮，跳过本次活动")
```

但「转交运送委托」条目位于任务面板列表的**折叠线以下**，需要向下滚动才会出现，
因此该 5 秒静态查找必然漏判，并把整个地区的转交流程当成「不可转交」而中断。

失败当刻的面板 OCR 只包含：

```
疑云 | 武陵城 | 亡者之舞 | 血色的叩问 | 枢纽区 | 任务奖励 | 科学兴农 | 重逢故人·其一 | 停止追踪 | ×
```

面板确实已打开，只是「转交运送委托」在可视区之外。

同仓库 `daily_credit_mixin.collect_credit` 对好友列表已使用标准滚动重试
（`scroll_count >= 7` + `scroll_relative(0.5, 0.5, -4)`），说明该能力已具备，
只是 `delivery_send_others` 未使用。

## 改动

新增 `_click_transfer_commission_in_task_panel`：先静态识别一次（保持原行为、原超时），
未命中则在面板内向下滚动重试，滚动次数与 `collect_credit` 保持一致（最多 7 次）。

```python
def _click_transfer_commission_in_task_panel(self, max_scroll=7):
    if self.wait_click_ocr(match=..., box=self.box.bottom_left, time_out=5):
        return True

    for _ in range(max_scroll):
        self.scroll_relative(0.5, 0.5, -4)
        self.wait_ui_stable(refresh_interval=1)
        if self.wait_click_ocr(match=..., box=self.box.bottom_left, time_out=5):
            return True
    return False
```

调用点替换为：

```python
if not self._click_transfer_commission_in_task_panel():
    self.log_info("未找到 '转交运送委托' 按钮，跳过本次活动")
    self.ensure_main()
    break
```

日志文本与原有分支行为保持一致；命中即点击（`wait_click_ocr` 语义不变），
未命中时仍走原来的 `ensure_main()` + `break`，不改变成功路径的调用顺序与参数。

## 测试

新增 `tests/TestDeliveryCommissionPanelScroll.py`：

- `test_found_without_scrolling` —— 首屏即命中，不产生滚动
- `test_found_after_scrolling_down` —— 滚动两次后命中
- `test_not_found_exhausts_scroll_budget` —— 滚动预算（7 次）耗尽后返回 False

`python -m unittest discover -s tests -p "Test*.py"` 下新增 3 项与既有
`TestDeliveryRewardsClaim`（7 项）全部通过。

## 另一个未在此 PR 处理的缺口（供参考）

同一函数内还有第二处独立缺口：点「查看报价」后游戏并未进入装箱/确认界面，
而是给出前置提示「有待运送的货物，请先完成送货」，导致 `FeatureList.give_gift`
5 秒超时（失败当刻整屏 OCR 只剩该提示）。该问题可能关联到任务计划中
`⭐转交运送委托`（`src/tasks/onetime/DailyTask.py:179`）排在
`⭐自动送货`（`:180`）之前——但顺序与前置状态需要先实机确认，故未纳入本 PR。

另外，该流程在失败时 `break` 会丢弃同一地区剩余的可转交活动
（实测某地区 `activity_num=3`，仅尝试了 1 次），如需一并处理建议单独讨论。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug 修复**
  - 优化任务面板中的“转交运送委托”按钮识别流程。
  - 当按钮位于折叠线下方或需要滚动查看时，系统会自动向下查找并尝试点击，减少误判为无法转交的情况。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->