### PR TITLE
chore: 升级 ok-script 到 2.0.7b1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -105,7 +105,7 @@ jobs:
           # 准备最小内联环境：只需 ok-script/pyappify 本体（依赖链为纯标准库），
           # 避免 uv run 同步项目全量依赖（PySide6/opencv 等数百 MB）
           uv venv .venv
-          uv pip install --python .venv --no-deps ok-script==2.0.2 pyappify==1.0.13
+          uv pip install --python .venv --no-deps ok-script==2.0.7b1 pyappify==1.0.13
 
       - name: inline_ok_requirements #把ok-script加入源码, 从requirements.txt中删除以提高升级更新速度
         env:
@@ -196,7 +196,7 @@ jobs:
           # 准备最小内联环境：只需 ok-script/pyappify 本体（依赖链为纯标准库），
           # 避免 uv run 同步项目全量依赖（PySide6/opencv 等数百 MB）
           uv venv .venv
-          uv pip install --python .venv --no-deps ok-script==2.0.2 pyappify==1.0.13
+          uv pip install --python .venv --no-deps ok-script==2.0.7b1 pyappify==1.0.13
 
       - name: inline_ok_requirements #把ok-script加入源码, 从requirements.txt中删除以提高升级更新速度
         env:
@@ -283,7 +283,7 @@ jobs:
           # 准备最小内联环境：只需 ok-script/pyappify 本体（依赖链为纯标准库），
           # 避免 uv run 同步项目全量依赖（PySide6/opencv 等数百 MB）
           uv venv .venv
-          uv pip install --python .venv --no-deps ok-script==2.0.2 pyappify==1.0.13
+          uv pip install --python .venv --no-deps ok-script==2.0.7b1 pyappify==1.0.13
 
       - name: inline_ok_requirements #把ok-script加入源码, 从requirements.txt中删除以提高升级更新速度
         env:

--- a/.github/workflows/pr-test.yml
+++ b/.github/workflows/pr-test.yml
@@ -74,7 +74,7 @@ jobs:
         run: |
           pip install uv==0.10.9
           uv venv .venv
-          uv pip install --python .venv --no-deps ok-script==2.0.2 pyappify==1.0.13
+          uv pip install --python .venv --no-deps ok-script==2.0.7b1 pyappify==1.0.13
 
       - name: inline_ok_requirements
         env:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = "Endfield game automation built on ok-script"
 requires-python = ">=3.12,<3.13"
 dependencies = [
-    "ok-script==2.0.4",
+    "ok-script==2.0.7b1",
     "PySide6-Essentials==6.11.1",
     "PySide6-Fluent-Widgets==1.10.5",
     "PySideSix-Frameless-Window==0.7.3",

--- a/requirements.txt
+++ b/requirements.txt
@@ -36,7 +36,7 @@ numpy==2.2.6
     #   opencv-python
     #   openvino
     #   shapely
-ok-script==2.0.4
+ok-script==2.0.7b1
     # via ok-end-field
 onnxocr-ppocrv5==0.0.14
     # via ok-end-field

--- a/uv.lock
+++ b/uv.lock
@@ -228,7 +228,7 @@ requires-dist = [
     { name = "cryptography", specifier = ">=44.0.0" },
     { name = "json5", specifier = "==0.15.0" },
     { name = "numpy", specifier = ">=2.0.0" },
-    { name = "ok-script", specifier = "==2.0.4" },
+    { name = "ok-script", specifier = "==2.0.7b1" },
     { name = "onnxocr-ppocrv5", specifier = "==0.0.14" },
     { name = "opencv-python", specifier = "==4.12.0.88" },
     { name = "openvino", specifier = "==2026.0.0" },
@@ -252,7 +252,7 @@ dev = [
 
 [[package]]
 name = "ok-script"
-version = "2.0.4"
+version = "2.0.7b1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "mouse" },
@@ -265,9 +265,9 @@ dependencies = [
     { name = "requests" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c7/e6/f9fbac76aca85f38dc8e1464701d7a22b9e653ec8e1e2bf50d2577522f8b/ok_script-2.0.4.tar.gz", hash = "sha256:5dc3a90a12e374d72dafef8415952bcfa76035f0f5aab831de7ad8b06c2265cb", size = 1082937, upload-time = "2026-08-20T17:09:35.206Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/df/e27d453882a7fadab94f0d7d9540e9ab836aacfb05ab7312a52e5e73bd03/ok_script-2.0.7b1.tar.gz", hash = "sha256:b3c95121ee60cb4c0904c1592db50e85e9b1dd72587b716b4a2658ce8371abdf", size = 1117009, upload-time = "2026-09-05T09:56:02.237Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d4/2f/211fd57e153057ab58756e1aa59489fca1f81c991e43fc360c765ddf5dc6/ok_script-2.0.4-py3-none-any.whl", hash = "sha256:425dcc023f8000a610bbf8de38c454e0f940e2cf3f92e67ea1d6eae2078016da", size = 1113286, upload-time = "2026-08-20T17:09:33.67Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/c9/9fbc47e8acf50ded04a234a7522d29de6856d56186ec264e3c1a2f08aa32/ok_script-2.0.7b1-py3-none-any.whl", hash = "sha256:7d9b9570d22390f9edcd612ea2a700e9365b8706318caeb6e520f7228de1fe75", size = 1139070, upload-time = "2026-09-05T09:56:00.716Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
升级依赖 ok-script 到 2.0.7b1，仅涉及 `pyproject.toml` 与 `uv.lock`，无业务代码改动。


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **维护**
  - 更新 `ok-script` 至 2.0.7b1，统一项目依赖与自动化环境中的版本。
  - 保持现有构建、同步及测试流程配置不变。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->