### PR TITLE
chore: 忽略 .workbuddy-ai/ 本地工作目录

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,6 +81,8 @@ python/
 !.vscode/extensions.json
 !.vscode/settings.json
 .workbuddy/
+# WorkBuddy AI 的本地工作目录（记忆 / 临时文件，不入库）
+.workbuddy-ai/
 
 ############################
 # 🖥 PyInstaller


### PR DESCRIPTION
与既有的 `.workbuddy/` 规则对齐。

`.workbuddy-ai/` 存放 WorkBuddy AI 的本地记忆与临时文件，不应进入版本控制。
此前未加入忽略，会以未跟踪项出现在 `git status` 里。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **维护**
  * 更新忽略规则，避免将本地工作目录及其临时文件纳入版本控制。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->